### PR TITLE
Fix domain statistic header duplication

### DIFF
--- a/src/dashboard/dashboard.js
+++ b/src/dashboard/dashboard.js
@@ -592,6 +592,34 @@ function handleDrilldownExit() {
     </div>
   `;
 
+  // Restore original table column headers
+  const thead = document.querySelector('.data-table thead');
+  if (thead) {
+    thead.innerHTML = `
+      <tr>
+        <th class="sortable" data-sort="domain">
+          Domain
+          <span class="sort-indicator"></span>
+        </th>
+        <th class="sortable" data-sort="count">
+          Visits
+          <span class="sort-indicator"></span>
+        </th>
+        <th class="sortable" data-sort="subpaths">
+          Subpaths
+          <span class="sort-indicator"></span>
+        </th>
+        <th class="sortable" data-sort="lastVisit">
+          Last Visit
+          <span class="sort-indicator"></span>
+        </th>
+        <th>Limit</th>
+        <th>Status</th>
+        <th>Actions</th>
+      </tr>
+    `;
+  }
+
   // Re-setup table controls
   setupTableControls();
 


### PR DESCRIPTION
Previously, when drilling down into a domain to view path statistics, the table headers were changed to "Subpath, Visits, Last Visit, % of Total". When exiting the drilldown view, only the panel title was restored to "Domain Statistics", but the table column headers remained as path headers.

This fix restores the original table column headers (Domain, Visits, Subpaths, Last Visit, Limit, Status, Actions) when exiting the drilldown view.