### PR TITLE
Add domain counter to badge display

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "FocusBear",
   "version": "0.1.0",
-  "version_name": "0.1.0-a2f8c4e",
+  "version_name": "0.1.0-c3af83f",
   "description": "Track your focus-switching habits with playful, privacy-first visualizations",
   "permissions": [
     "tabs",

--- a/src/background/badge.js
+++ b/src/background/badge.js
@@ -1,0 +1,35 @@
+/**
+ * FocusBear Badge Module
+ * Updates extension badge with domain count
+ */
+
+import { getTodayDomainCount } from './storage.js';
+
+/**
+ * Update extension badge with current domain count
+ */
+export async function updateDomainBadge() {
+  try {
+    const count = await getTodayDomainCount();
+    const badgeText = count > 0 ? count.toString() : '';
+
+    // Set badge text
+    await chrome.action.setBadgeText({ text: badgeText });
+
+    // Set badge background color (Bear Blue from brand guidelines)
+    await chrome.action.setBadgeBackgroundColor({ color: '#0E75B6' });
+
+    console.log(`Badge updated: ${count} domains tracked today`);
+  } catch (error) {
+    console.error('Error updating domain badge:', error);
+  }
+}
+
+/**
+ * Initialize badge on extension startup
+ */
+export async function initializeBadge() {
+  console.log('Initializing domain counter badge...');
+  await updateDomainBadge();
+  console.log('Domain counter badge initialized');
+}

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -5,6 +5,7 @@
 
 import { initializeTracking, trackCurrentTab } from './tracking.js';
 import { initializeLimitEnforcement } from './limits.js';
+import { initializeBadge } from './badge.js';
 
 async function openDashboardTab() {
   const dashboardUrl = chrome.runtime.getURL('src/dashboard/index.html');
@@ -49,6 +50,9 @@ chrome.runtime.onInstalled.addListener(async (details) => {
 
   // Initialize limit enforcement
   initializeLimitEnforcement();
+
+  // Initialize domain counter badge
+  await initializeBadge();
 });
 
 // Initialize tracking when service worker starts
@@ -57,6 +61,11 @@ initializeTracking();
 
 // Initialize limit enforcement
 initializeLimitEnforcement();
+
+// Initialize domain counter badge
+initializeBadge().catch((error) => {
+  console.error('Error initializing badge on startup:', error);
+});
 
 // Track current tab on startup
 trackCurrentTab().catch((error) => {

--- a/src/background/storage.js
+++ b/src/background/storage.js
@@ -124,6 +124,15 @@ export async function getTodayVisits() {
 }
 
 /**
+ * Get count of unique domains visited today
+ * @returns {Promise<number>} Number of unique domains
+ */
+export async function getTodayDomainCount() {
+  const todayVisits = await getTodayVisits();
+  return Object.keys(todayVisits).length;
+}
+
+/**
  * Increment visit count for a domain
  * @param {string} domain - Domain name (e.g., "example.com")
  * @param {string} [subpath] - Optional subpath (e.g., "/page1")

--- a/src/background/tracking.js
+++ b/src/background/tracking.js
@@ -5,6 +5,7 @@
 
 import { incrementVisit } from './storage.js';
 import { updateBlockingRules } from './limits.js';
+import { updateDomainBadge } from './badge.js';
 
 /**
  * Extract domain and subpath from URL
@@ -57,6 +58,9 @@ async function trackTabFocus(tabId) {
     const newCount = await incrementVisit(domain, subpath);
 
     console.log(`Focus switch recorded: ${domain}${subpath} (count: ${newCount})`);
+
+    // Update domain counter badge
+    await updateDomainBadge();
 
     // Check if this domain has a limit and show countdown toast
     await showCountdownToastIfNeeded(tabId, domain);


### PR DESCRIPTION
Implements a real-time counter badge that displays the number of unique domains visited today on the extension icon. The badge updates automatically after each tab switch.

Changes:
- Created src/background/badge.js module for badge management
- Added getTodayDomainCount() function in storage.js
- Integrated updateDomainBadge() into tab tracking flow
- Initialize badge on extension startup and service worker restart
- Uses Bear Blue (#0E75B6) brand color for badge background

The badge shows:
- Empty when no domains visited today
- Numeric count (e.g., "5") for 1+ domains

This provides users with at-a-glance visibility of their browsing activity directly from the extension icon.