### PR TITLE
Pre: Agent environment — dev-setup + CLAUDE/AGENTS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,7 +7,8 @@ build/
 *.zip
 
 # Documentation (auto-generated)
-docs/
+docs/*
+!docs/dev-setup.md
 
 # Test coverage
 coverage/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,12 +17,25 @@
     - Before running any Python script, **activate the appropriate virtual environment** and document its usage.
   - Prefer readability over cleverness; optimize for maintainability for a solo/early-stage team.
 
+- **Recorded Commands — Single Source of Truth: `docs/dev-setup.md` (also summarized in `CLAUDE.md`)**
+  - Toolchain: `npm ci` in a clean checkout (never `npm install` for verification), Node ≥20 (final policy ≥22 via Task 2.1 → `engines.node` + `.nvmrc` + CI matrix `[22.x, 24.x]`), Chrome 100+, `git`/`bash` on PATH.
+  - **Test command of record:** `npm test -- --ci` — its pass rate recorded in Task 0.1 is the floor (≥) for every later P0–P4 task. Coverage variant: `npm run test:coverage -- --ci`. Until 0.1, the RED baseline (`jest: command not found`, CI green at 2025-12-01) is expected — docs/dev-setup.md states this and points to 0.1.
+  - **Five recorded commands (run as written):** `npm run build` · `npm test -- --ci` · `npm run lint` (`format:check && eslint "src/**/*.js"`) · `npm run format:check` · `cd landing-page && npm ci && npm run build` (plus `npm run lint`/`format:check`/`build` in `landing-page/` after Task 0.4; after 2.6/2.7 they run on ESLint 9 flat config). Every change must keep `npm run lint` and `npm run format:check` green.
+  - **Build determinism:** after Task 0.3, `npm run build` must not mutate tracked `manifest.json`; `git status --porcelain` stays clean and `dist/manifest.json` carries `version_name` `base-version-commit-sha`.
+  - **CI parity:** `.github/workflows/ci.yml` runs exactly these five on every push/PR (lint-and-test + coverage, plus landing job after 0.4; matrix migrates to 22/24 in 2.1). Keep CI in sync with this doc.
+
+- **Storage-Writer Contract (Tasks 0.2 / 3.1–3.3 — obey even before those tasks land)**
+  - Single atomic per-domain mutation path: all visit increments go through `src/background/storage.js` `incrementVisit` (or its predecessor helpers) — never inline `storage.get` + `set` read-modify-write. After 3.1 it is a serialized queue/lock with `chrome.runtime.lastError` checking and bounded timestamp retention (old timestamps compacted, storage write volume no longer scales with history).
+  - Single date-key utility: use the canonical `YYYY-MM-DD` helper introduced in 3.3 (local-tz aware) — never inline `toISOString().split('T')[0]` (grep-clean requirement after 3.3). Until 3.3, note UTC vs local-midnight mismatch as known debt (F-BUG-004).
+  - Single limit-form controller: after 3.3, all three limit forms share one validated controller (positive integer, same rejection of 0/negatives, same max). Legacy numeric limits normalized at the storage getter boundary (fixed in 0.2).
+  - Never register SW listeners inside `onInstalled` (double-count bug F-BUG-002, fixed in 0.2); keep only first-run seeding there.
+
 - **Best Practices (Testing, Documentation, CI/CD)**
   - Implement tests for core logic:
-    - Data aggregation (time ranges, per-domain counts).
-    - Limit enforcement and block-page triggering.
-    - Streak and average computations.
-  - Add at least a smoke test/integration check for popup load and background event handling.
+    - Data aggregation (time ranges, per-domain counts) — use the shared time-range aggregator from 3.3, not ad-hoc filters.
+    - Limit enforcement and block-page triggering — cover legacy-limit normalization and `chrome.runtime.lastError` quota path.
+    - Streak and average computations — single-pass focus-score after 3.2 (one storage read per dashboard load, zero unnecessary `overallStreak` writes).
+  - Add at least a smoke test/integration check for popup load and background event handling (required by Task 0.1 to void F-TEST-003; keep them green).
   - Always create and maintain **GitHub Actions** CI workflows:
     - At minimum: install dependencies, run linting, run tests, and build the extension.
     - Ensure CI fails on lint/test/build errors.
@@ -33,6 +46,7 @@
   - Keep internal documentation up to date:
     - Briefly document any new module, major function, or architectural decision in code comments or a short markdown note.
     - When adding/removing features, update `tasks.md` status and ensure behavior stays aligned with `prd.md`.
+    - Keep `docs/dev-setup.md`, `CLAUDE.md`, and `AGENTS.md` in sync on the recorded commands, storage-writer contract, and module layout (`background/popup/dashboard/shared`).
 
 - **Security Considerations**
   - Respect FocusBear’s **local-only, privacy-first** design:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -139,48 +139,53 @@ Block Page
 - **Performance:** Chrome DevTools profiling for popup/graph responsiveness
 - **Accessibility:** Lighthouse audit, manual WCAG 2.1 AA checks, keyboard navigation testing
 
-## Common Development Commands
+## Common Development Commands — Recorded Commands (test command of record: `npm test -- --ci`)
 
-### Build & Development
+> **Source of truth:** `docs/dev-setup.md` — toolchain (`npm ci` clean checkout), Node ≥20 (final policy ≥22 via Task 2.1), Chrome 100+, plus the five recorded commands every P0–P4 task verifies against. Until Task 0.1 restores the suite, the RED baseline means `npm test -- --ci` may report `jest: command not found`; see that file for expected outputs and the smoke-test additions (popup DOM load + SW `onInstalled`/`onActivated` wiring).
 
 ```bash
-# Install dependencies
-npm install
-
-# Update version with git commit hash
-# Updates manifest.json version_name to include current commit hash (e.g., "0.1.0-7205313")
-npm run version:update
-
-# Build/bundle extension (minify JS/CSS)
-# Automatically runs version:update before building
+# 1. Build the extension (deterministic after 0.3 — git status clean after build)
 npm run build
+# = npm run version:update && node scripts/build.js  → dist/manifest.json + dist/src + dist/assets
 
-# Development mode (watch for changes)
-npm run dev
+# 2. Test — command of record (≥ pass rate recorded in 0.1 is the floor for all later tasks)
+npm test -- --ci
+# Coverage: npm run test:coverage -- --ci  → coverage/lcov.info for codecov
 
-# Lint code with ESLint
+# 3. Lint (format check + ESLint)
 npm run lint
+# = npm run format:check && eslint "src/**/*.js"
 
-# Fix linting issues automatically
-npm run lint:fix
-
-# Format code with Prettier
-npm run format
-
-# Check code formatting
+# 4. Format check only
 npm run format:check
+# Fix locally: npm run format  or  npm run lint:fix
 
-# Run tests
-npm run test
+# 5. Landing-page second package (own lockfile, own CI job after 0.4)
+cd landing-page && npm ci && npm run build
+# Also in CI: npm run lint -- --max-warnings 0  &&  npm run format:check  &&  npm run build
 
-# Run single test file
-npm run test -- tests/background/limits.test.js
+# Legacy helpers (still valid, but not part of the five recorded)
+npm ci                          # deterministic install from lockfile — use over npm install for verification
+npm run version:update          # updates manifest version_name with git hash (auto via build)
+npm run dev                     # watch mode via scripts/watch.js
+npm run lint:fix                # prettier --write + eslint --fix
+npm run test -- tests/background/limits.test.js  # single-file run
+npm run icons:generate          # sharp-based icon generation (Task 2.9)
+```
 
-# Load extension in Chrome
-# 1. Open chrome://extensions/
-# 2. Enable "Developer mode"
-# 3. Click "Load unpacked"
-# 4. Select project root directory
+### Architecture Constraints — Storage / Limits (local-only, MV3)
+
+- **Storage is local-only:** all state in `chrome.storage.local` via helpers in `src/background/storage.js`. No external APIs, no telemetry, no cloud sync. Never add a remote write path without explicit instruction.
+- **Atomic visit mutation:** after Task 3.1, `incrementVisit` is a serialized, bounded writer (check `chrome.runtime.lastError`, cap timestamp retention, no read-modify-write races). Before 3.1, direct `storage.get`+`set` races lose counts.
+- **Limit enforcement:** `src/background/limits.js` + `src/background/notifications.js` + `src/background/focus-score.js` share a single normalization boundary for legacy numeric limits (`{ "example.com": 10 }` → `{ daily: 10, fiveHours: … }`) — fixed in 0.2. The shared date-key utility (Task 3.3) is the only correct `YYYY-MM-DD` source (local-tz aware); inline `toISOString().split('T')[0]` is legacy.
+- **MV3 service worker:** `src/background/index.js` registers `tabs.onActivated`/`onUpdated`/`onInstalled`/`storage.onChanged` listeners **top-level only** — never inside `onInstalled` (double-registration bug fixed in 0.2). Requires `tabs`, `storage`, `notifications`, `declarativeNetRequest*`, `<all_urls>`.
+- **Module layout:** `background/` (tracking/storage/limits/focus-score/achievements/badge) · `popup/` + `popup/graph.js` (D3 radial graph) · `dashboard/` (full-page dashboard, blocking, domain) · `blocked/` · `help/` · `content/countdown-toast.js` · `common/visualization-page.js` (shared helpers) · `landing-page/` (Vite/React second package) — see `docs/dev-setup.md` for the full tree.
+
+Load unpacked for manual testing:
+```bash
+# 1. Open chrome://extensions/ → Developer mode ON
+# 2. Load unpacked → select dist/ (after npm run build)
+# 3. Inspect: service_worker / popup / dashboard; check storage: chrome.storage.local.get(null, d => console.log(d))
 ```
 
 ### Version Management

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,0 +1,156 @@
+# Development Setup — FocusBear
+
+This document describes how to set up a runnable development environment for FocusBear from a clean checkout. It is the single source for toolchain, required environment, and the five recorded commands that CI and local verification use.
+
+> **Baseline status: RED at audit (2026-08-30, commit `7d5299f`).**
+> A clean `npm ci` checkout builds in an isolated probe, but the local test suite could not start (`jest: command not found`) and lint/format tooling was not installed locally; the last CI run (2025-12-01, run 19828167779) was green. Until **Task 0.1 — Restore a runnable, recorded baseline** lands and records the new pass rate, the commands below may still fail locally. Follow the steps exactly, then run `0.1` fixes to reach green. See `MODERNIZATION_PLAN.md` Task 0.1, `MODERNIZATION_REPORT.md` (Baseline: RED), and `docs/tasks.md`.
+
+---
+
+## Required Environment
+
+- **Node.js** — `>=20` required now; final policy will be `>=22` (see `MODERNIZATION_PLAN.md` Task 2.1 → `engines.node`, `.nvmrc`, CI matrix `[22.x, 24.x]`). Use `nvm`/`fnm` with `.nvmrc` once 2.1 lands. Current CI matrix is `[18.x, 20.x]` (EOL — to be replaced in 2.1).
+- **npm** — ships with Node. Use `npm ci` in a clean checkout (never `npm install` for CI/verification) to get deterministic installs from `package-lock.json`.
+- **Chrome** — version `100+` required for MV3 service-worker, `tabs`, `storage`, `webRequest`/`declarativeNetRequest`, `notifications` APIs. Load the built `dist/` folder via `chrome://extensions → Load unpacked`.
+- **OS** — macOS/Linux/WSL supported. `scripts/update-version.sh` handles both `darwin` and `linux` `sed` variants.
+- **Tools assumed on PATH** — `git`, `bash`, `node`, `npm`, `chrome` (or Chromium).
+
+---
+
+## Toolchain Install (clean checkout)
+
+```bash
+# 1. Clone and enter
+git clone https://github.com/luongnv89/focus-bear.git
+cd focus-bear
+
+# 2. Install root package deterministically (requires package-lock.json)
+npm ci
+
+# 3. Install landing-page package (second lockfile)
+cd landing-page && npm ci && cd ..
+
+# Expected output (abbrev.):
+# added 300+ packages, and audited ... packages
+# found 0 vulnerabilities (after W1/W2 patches; may show High/Critical before 1.1–1.4)
+```
+
+Re-run `npm ci` after switching branches or pulling lockfile changes. Do not commit `node_modules/`, `dist/`, or `coverage/` — they are gitignored.
+
+---
+
+## Recorded Commands (test command of record)
+
+All tasks `P0–P4` verify against these five commands. Prefer them over ad-hoc variants.
+
+### 1. Build the extension
+
+```bash
+npm run build
+# Internally: npm run version:update && node scripts/build.js
+# Expected: "Building FocusBear extension..." → "Build complete! Output in dist/"
+# Output tree: dist/manifest.json, dist/src/, dist/assets/
+# After Task 0.3 the build no longer mutates tracked manifest.json;
+# git status --porcelain must be clean after build (verify: `npm run build && git status --porcelain`).
+```
+
+### 2. Run the test suite (command of record)
+
+```bash
+npm test -- --ci
+# Expected before 0.1: sh: jest: command not found (RED baseline — Jest not installed locally, CI green)
+# Expected after 0.1: Jest summary + pass rate, smoke tests for popup DOM load and SW onInstalled/onActivated wiring
+# Coverage variant: npm run test:coverage -- --ci  (produces coverage/lcov.info, consumed by codecov in CI)
+```
+
+The pass rate recorded in `0.1` becomes the floor for every later task (`≥ recorded rate`). CI runs the same command in both `lint-and-test` and `coverage` jobs.
+
+### 3. Lint
+
+```bash
+npm run lint
+# = npm run format:check && eslint "src/**/*.js"
+# Expected after 0.1: 0 errors, 0 warnings (after Task 2.6/2.7 ESLint 9 migration, flat config)
+# Before that, a written list of pre-existing violations is acceptable per 0.1 AC.
+```
+
+### 4. Format check
+
+```bash
+npm run format:check
+# = prettier --check "src/**/*.{js,html,css}"
+# Expected: "All matched files use Prettier code style!" or exit 0
+# Fix: npm run format  (or npm run lint:fix)
+```
+
+### 5. Build the landing page (second package)
+
+```bash
+cd landing-page && npm ci && npm run build
+# Internally: vite build (manual chunk splitting per research.md)
+# Expected: "vite v5.x building for production..." → "✓ built in ...s"
+# Additional checks (landed in CI by Task 0.4):
+#   npm run lint -- --max-warnings 0
+#   npm run format:check
+# Verify build: npm run preview (then open localhost:4173, smoke-check Landing + /privacy)
+```
+
+---
+
+## Pre-commit & CI Parity
+
+- **Husky + lint-staged**: `npm install` installs `.husky/pre-commit` which runs `eslint --fix`, `prettier --write`, and `jest --bail --findRelatedTests --passWithNoTests` on staged `src/**/*.js` plus `prettier` on `html/css`. To bypass (not recommended): `git commit --no-verify`.
+- **CI** (`.github/workflows/ci.yml`): on every `push`/`pull_request`
+  - `lint-and-test` matrix `[18.x, 20.x]` → `npm ci → npm run lint → npm run format:check → npm test → npm run build` + artifact `dist/`
+  - `coverage` → `npm test -- --coverage` → `codecov/codecov-action@v4`
+  - After 0.4: additional `landing` job → `cd landing-page && npm ci && npm run lint && npm run format:check && npm run build`
+  - After 2.1: matrix becomes `[22.x, 24.x]` with `engines.node >=22` and `.nvmrc` alignment
+
+CI must be green before any `P1+` task is considered done.
+
+---
+
+## Module Layout Note (for agents)
+
+```
+src/
+  background/          # Service worker (MV3, type: module)
+    index.js           # entry — registers top-level listeners (tabs, storage, notifications)
+    tracking.js        # tab focus tracking, domain extraction, visit counting
+    storage.js         # chrome.storage.local helpers, atomic visit mutation (Task 3.1)
+    limits.js          # limit checking/enforcement, legacy-limit normalization (Task 0.2)
+    notifications.js   # countdown/bubble logic, limit warnings
+    focus-score.js     # 0–100 score, compliance & streak helpers
+    achievements.js    # streak/badge logic (survives dead-code removal 3.4)
+    badge.js           # toolbar badge text
+  dashboard/           # full-page dashboard (index.html + dashboard.js/css, blocking, domain)
+  popup/               # popup + graph.js (D3 radial graph)
+  blocked/             # block page
+  help/                # help/FAQ
+  content/             # countdown-toast content script
+  common/              # shared utils (visualization-page.js, feature-flags.js, categories.js)
+landing-page/          # Vite + React 18 landing site (second lockfile, own CI job)
+scripts/               # build.js, update-version.sh (0.3 makes version stamping deterministic), generate-icons.js
+tests/                 # Jest tests (smoke + unit after 0.1)
+```
+
+Storage is **local-only** (`chrome.storage.local`), never remote; MV3 `manifest.json` permissions are least-privilege (`tabs`, `storage`, `notifications`, `declarativeNetRequest*`, `<all_urls>` host — justified in PRIVACY.md after 4.5).
+
+---
+
+## Quick Smoke After Setup
+
+```bash
+npm ci && npm run build && npm test -- --ci   # M0 gate (after 0.1)
+npm run lint && npm run format:check           # must pass
+cd landing-page && npm ci && npm run build     # second package green
+git status --porcelain                         # must be empty after build (0.3)
+```
+
+If any step fails with `command not found`, re-run `npm ci` in that package and verify Node ≥20 via `node -v`. For `jest: command not found` before 0.1, that is the expected RED baseline — no action beyond running 0.1.
+
+---
+
+## How to Point Future Agents Here
+
+`CLAUDE.md` and `AGENTS.md` both reference this file as the authoritative install/run notes and list the same five recorded commands plus the module layout and storage/limits constraints. Keep them in sync when this file changes (see `MODERNIZATION_PLAN.md` Pre.2/Pre.3).


### PR DESCRIPTION
Closes #16, #17, #18

- #16 Pre.1: docs/dev-setup.md with toolchain (npm ci), Node >=20 (final >=22), Chrome, five recorded commands, RED baseline note pointing to 0.1, module layout, .gitignore fix (docs/* + !docs/dev-setup.md)
- #17 Pre.2: CLAUDE.md improved — recorded commands, storage/limits MV3 constraints, module layout, references docs/dev-setup.md
- #18 Pre.3: AGENTS.md improved — recorded commands, storage-writer contract (incrementVisit queue, date-key, limit-form), sync note

Verify: test -f docs/dev-setup.md && grep -q 'npm ci' docs/dev-setup.md; git check-ignore docs/dev-setup.md not ignored; .gitignore still covers node_modules/dist/coverage