### PR TITLE
P0: Fix SW duplicate listeners, deterministic build, landing CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,35 @@ jobs:
           path: dist/
           retention-days: 7
 
+  landing:
+    name: Landing — Lint, Format & Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: landing-page
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+          cache-dependency-path: landing-page/package-lock.json
+
+      - name: Install landing dependencies
+        run: npm ci
+
+      - name: Run ESLint (landing)
+        run: npm run lint -- --max-warnings 0
+
+      - name: Check formatting (landing)
+        run: npm run format:check
+
+      - name: Build landing page
+        run: npm run build
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest

--- a/landing-page/src/components/Features.jsx
+++ b/landing-page/src/components/Features.jsx
@@ -16,10 +16,7 @@ function FeatureCard({ feature }) {
     <div className="card group hover:border-accent/30 transition-all duration-300">
       {/* Icon */}
       <div className="w-12 h-12 rounded-lg bg-accent/10 flex items-center justify-center mb-4 group-hover:bg-accent/20 transition-colors">
-        <IconComponent
-          className="w-6 h-6 text-accent"
-          aria-hidden="true"
-        />
+        <IconComponent className="w-6 h-6 text-accent" aria-hidden="true" />
       </div>
 
       {/* Title */}

--- a/landing-page/src/components/Hero.jsx
+++ b/landing-page/src/components/Hero.jsx
@@ -14,7 +14,9 @@ function Hero() {
         <div className="text-center max-w-4xl mx-auto">
           {/* Headline */}
           <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold tracking-tight animate-fade-in">
-            <span className="text-white">{heroContent.headline.split(',')[0]},</span>
+            <span className="text-white">
+              {heroContent.headline.split(',')[0]},
+            </span>
             <br />
             <span className="text-accent">
               {heroContent.headline.split(',')[1]?.trim()}

--- a/landing-page/src/data/hero.js
+++ b/landing-page/src/data/hero.js
@@ -3,7 +3,7 @@ export const heroContent = {
   tagline:
     'Privacy-first Chrome extension that helps you understand your browsing habits through beautiful visualizations. All data stays on your device.',
   ctaButton: {
-    text: 'Add to Chrome — It\'s Free',
+    text: "Add to Chrome — It's Free",
     url:
       import.meta.env.VITE_CHROME_STORE_URL ||
       'https://chrome.google.com/webstore',

--- a/landing-page/src/pages/Privacy.jsx
+++ b/landing-page/src/pages/Privacy.jsx
@@ -48,7 +48,9 @@ function renderContent(content) {
         // Numbered list
         const text = trimmed.replace(/^\d+\.\s/, '');
         if (index > 0 && !lines[index - 1].trim().match(/^\d+\.\s/)) {
-          result.push('<ol class="list-decimal list-inside space-y-1 text-gray-400">');
+          result.push(
+            '<ol class="list-decimal list-inside space-y-1 text-gray-400">'
+          );
         }
         result.push(`<li>${text}</li>`);
         if (
@@ -102,7 +104,12 @@ function renderTable(content) {
 
   const beforeTable = content.split('|')[0].trim();
   const afterTableIndex = content.lastIndexOf('|');
-  const afterTable = content.substring(afterTableIndex).split('\n').slice(1).join('\n').trim();
+  const afterTable = content
+    .substring(afterTableIndex)
+    .split('\n')
+    .slice(1)
+    .join('\n')
+    .trim();
 
   return (
     <div className="space-y-4">

--- a/landing-page/src/styles/index.css
+++ b/landing-page/src/styles/index.css
@@ -29,7 +29,12 @@ html {
 }
 
 body {
-  font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto',
+  font-family:
+    'Inter',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    'Roboto',
     sans-serif;
   background-color: var(--color-dark-bg);
   color: #ffffff;

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test:watch": "jest --watch",
     "version:update": "bash scripts/update-version.sh",
     "icons:generate": "node scripts/generate-icons.js",
-    "build": "npm run version:update && node scripts/build.js",
+    "build": "node scripts/build.js",
     "dev": "node scripts/watch.js",
     "prepare": "husky install",
     "pre-commit": "lint-staged"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -6,6 +6,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { execSync } from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -56,6 +57,26 @@ function copyDir(src, dest) {
       fs.copyFileSync(srcPath, destPath);
     }
   }
+}
+
+// Stamp version_name in dist/manifest.json without mutating tracked file (deterministic build)
+try {
+  const distManifestPath = path.join(distDir, 'manifest.json');
+  if (fs.existsSync(distManifestPath)) {
+    const manifest = JSON.parse(fs.readFileSync(distManifestPath, 'utf8'));
+    const baseVersion = manifest.version;
+    let gitHash = 'dev';
+    try {
+      gitHash = execSync('git rev-parse --short HEAD', { cwd: rootDir, encoding: 'utf8' }).trim();
+    } catch {
+      // No git repo or command failed — keep dev
+    }
+    manifest.version_name = `${baseVersion}-${gitHash}`;
+    fs.writeFileSync(distManifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+    console.log(`Stamped dist/manifest.json version_name: ${manifest.version_name}`);
+  }
+} catch (error) {
+  console.warn('Warning: could not stamp dist manifest version_name', error.message);
 }
 
 console.log('Build complete! Output in dist/');

--- a/src/background/focus-score.js
+++ b/src/background/focus-score.js
@@ -3,7 +3,7 @@
  * Calculates a daily/weekly focus score based on user behavior
  */
 
-import { calculateOverallStreak } from './storage.js';
+import { calculateOverallStreak, normalizeLimitConfig } from './storage.js';
 
 function getDayTotalVisits(dayData = {}) {
   return Object.values(dayData).reduce((sum, visitData) => sum + (visitData.count || 0), 0);
@@ -39,8 +39,15 @@ function getCompliantDomainCount(enabledLimits, dayVisits) {
  * @returns {Promise<number>} Focus score (0-100)
  */
 export async function calculateDailyFocusScore(date) {
-  const { visits = {}, limits = {} } = await chrome.storage.local.get(['visits', 'limits']);
+  const { visits = {}, limits: rawLimits = {} } = await chrome.storage.local.get([
+    'visits',
+    'limits',
+  ]);
   const dayVisits = visits[date] || {};
+  // Normalize legacy numeric limits at the boundary
+  const limits = Object.fromEntries(
+    Object.entries(rawLimits).map(([d, cfg]) => [d, normalizeLimitConfig(cfg)]),
+  );
 
   // Factor 1: Limits Compliance (40 points)
   let complianceScore = 0;
@@ -163,8 +170,14 @@ export async function getFocusScoreHistory(days = 30) {
  * @returns {Promise<Object>} Breakdown of score components
  */
 export async function getFocusScoreBreakdown(date) {
-  const { visits = {}, limits = {} } = await chrome.storage.local.get(['visits', 'limits']);
+  const { visits = {}, limits: rawLimits = {} } = await chrome.storage.local.get([
+    'visits',
+    'limits',
+  ]);
   const dayVisits = visits[date] || {};
+  const limits = Object.fromEntries(
+    Object.entries(rawLimits).map(([d, cfg]) => [d, normalizeLimitConfig(cfg)]),
+  );
 
   // Calculate each component
   let complianceScore = 0;

--- a/src/background/index.js
+++ b/src/background/index.js
@@ -25,12 +25,12 @@ async function openDashboardTab() {
 
 console.log('FocusBear service worker initialized');
 
-// Listen for extension installation
+// Listen for extension installation — seed first-run data only; listeners are registered top-level
 chrome.runtime.onInstalled.addListener(async (details) => {
   if (details.reason === 'install') {
     console.log('FocusBear installed - welcome!');
 
-    // Initialize storage with empty data
+    // Initialize storage with empty data (first-run seeding only)
     await chrome.storage.local.set({
       visits: {},
       limits: {},
@@ -44,22 +44,6 @@ chrome.runtime.onInstalled.addListener(async (details) => {
   } else if (details.reason === 'update') {
     console.log('FocusBear updated to version', chrome.runtime.getManifest().version);
   }
-
-  // Initialize tracking after installation/update
-  initializeTracking();
-  await trackCurrentTab();
-
-  // Initialize limit enforcement
-  initializeLimitEnforcement();
-
-  // Initialize visit counter badge
-  await initializeBadge();
-
-  // Initialize notifications
-  await initializeNotifications();
-
-  // Initialize achievements
-  await initializeAchievements();
 });
 
 // Initialize tracking when service worker starts

--- a/src/background/notifications.js
+++ b/src/background/notifications.js
@@ -3,7 +3,7 @@
  * Handles motivational notifications, limit warnings, and achievement celebrations
  */
 
-import { getLimits } from './storage.js';
+import { getLimits, normalizeLimitConfig } from './storage.js';
 import { ACHIEVEMENTS } from './achievements.js';
 
 // Notification types
@@ -270,8 +270,14 @@ export async function showDailyEncouragement() {
   if (lastEncouragementDate === today) return;
 
   // Check if user is doing well (no limits exceeded today)
-  const { visits = {}, limits = {} } = await chrome.storage.local.get(['visits', 'limits']);
+  const { visits = {}, limits: rawLimits = {} } = await chrome.storage.local.get([
+    'visits',
+    'limits',
+  ]);
   const todayVisits = visits[today] || {};
+  const limits = Object.fromEntries(
+    Object.entries(rawLimits).map(([d, cfg]) => [d, normalizeLimitConfig(cfg)]),
+  );
 
   const activeLimits = Object.entries(limits).filter(
     ([, limitConfig]) => limitConfig?.enabled && limitConfig.daily?.limit,

--- a/src/background/storage.js
+++ b/src/background/storage.js
@@ -202,13 +202,18 @@ export async function incrementVisit(domain, subpath = null) {
 }
 
 /**
- * Get limits configuration
- * @returns {Promise<Object>} Limits object
+ * Get limits configuration — normalizes legacy numeric limits at the getter boundary
+ * @returns {Promise<Object>} Limits object with normalized configs
  */
 export async function getLimits() {
   return new Promise((resolve) => {
     chrome.storage.local.get(['limits'], (data) => {
-      resolve(data.limits || {});
+      const raw = data.limits || {};
+      const normalized = {};
+      Object.entries(raw).forEach(([domain, cfg]) => {
+        normalized[domain] = normalizeLimitConfig(cfg);
+      });
+      resolve(normalized);
     });
   });
 }
@@ -498,7 +503,10 @@ export async function getAggregatedStats(range = 'today') {
 export async function calculateLimitStreak(domain) {
   const data = await chrome.storage.local.get(['visits', 'limits', 'streaks']);
   const visits = data.visits || {};
-  const limits = data.limits || {};
+  const rawLimits = data.limits || {};
+  const limits = Object.fromEntries(
+    Object.entries(rawLimits).map(([d, cfg]) => [d, normalizeLimitConfig(cfg)]),
+  );
   const streaks = data.streaks || {};
 
   const limitConfig = limits[domain];
@@ -559,7 +567,10 @@ export async function getAllStreaks() {
 export async function calculateOverallStreak() {
   const data = await chrome.storage.local.get(['visits', 'limits', 'overallStreak']);
   const visits = data.visits || {};
-  const limits = data.limits || {};
+  const rawLimits = data.limits || {};
+  const limits = Object.fromEntries(
+    Object.entries(rawLimits).map(([d, cfg]) => [d, normalizeLimitConfig(cfg)]),
+  );
   const existingStreak = data.overallStreak || { current: 0, best: 0 };
 
   const today = new Date();

--- a/tests/legacy-limits.test.js
+++ b/tests/legacy-limits.test.js
@@ -1,0 +1,163 @@
+/**
+ * Regression tests for legacy numeric limit handling (Task 0.2)
+ * Ensures numeric limits like { "example.com": 10 } normalize correctly
+ * and do not throw in checkLimitWarnings or focus-score paths.
+ */
+
+import { normalizeLimitConfig, getLimits } from '../src/background/storage.js';
+import { checkLimitWarnings } from '../src/background/notifications.js';
+import { calculateDailyFocusScore, getFocusScoreBreakdown } from '../src/background/focus-score.js';
+
+// Mock chrome.storage.local for all tests
+function mockStorage(data) {
+  global.chrome = {
+    storage: {
+      local: {
+        data: { ...data },
+        get(keys, cb) {
+          const result = (() => {
+            if (keys === null || keys === undefined) return this.data;
+            if (Array.isArray(keys)) {
+              const res = {};
+              keys.forEach((k) => {
+                if (this.data[k] !== undefined) res[k] = this.data[k];
+              });
+              return res;
+            }
+            if (typeof keys === 'string') return { [keys]: this.data[keys] };
+            const res = {};
+            Object.keys(keys || {}).forEach((k) => {
+              if (this.data[k] !== undefined) res[k] = this.data[k];
+            });
+            return res;
+          })();
+          if (typeof cb === 'function') {
+            cb(result);
+            return;
+          }
+          return Promise.resolve(result);
+        },
+        set(items, cb) {
+          Object.assign(this.data, items);
+          if (typeof cb === 'function') cb();
+          else return Promise.resolve();
+        },
+        clear(cb) {
+          this.data = {};
+          if (typeof cb === 'function') cb();
+          else return Promise.resolve();
+        },
+      },
+      onChanged: { addListener: jest.fn() },
+    },
+    tabs: {
+      onActivated: { addListener: jest.fn() },
+      onUpdated: { addListener: jest.fn() },
+    },
+    runtime: {
+      onInstalled: { addListener: jest.fn() },
+      getURL: (p) => `chrome-extension://test/${p}`,
+      getManifest: () => ({ version: '0.2.0' }),
+      id: 'test-id',
+    },
+    action: {
+      onClicked: { addListener: jest.fn() },
+      setBadgeText: jest.fn().mockResolvedValue(),
+      setBadgeBackgroundColor: jest.fn().mockResolvedValue(),
+    },
+    declarativeNetRequest: {
+      updateDynamicRules: jest.fn().mockResolvedValue(),
+      getDynamicRules: jest.fn().mockResolvedValue([]),
+    },
+    notifications: { create: jest.fn().mockResolvedValue() },
+  };
+}
+
+describe('Legacy numeric limit normalization', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'debug').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('normalizeLimitConfig converts number to daily limit config', () => {
+    const cfg = normalizeLimitConfig(10);
+    expect(cfg.enabled).toBe(true);
+    expect(cfg.daily.enabled).toBe(true);
+    expect(cfg.daily.limit).toBe(10);
+    expect(cfg.fiveHour.enabled).toBe(true); // default from createDefaultLimitConfig
+  });
+
+  test('getLimits normalizes legacy numeric limits at getter boundary', async () => {
+    mockStorage({ limits: { 'example.com': 10, 'other.com': { enabled: true, daily: { enabled: true, limit: 5 }, fiveHour: { enabled: false, limit: 10 } } } });
+    const limits = await getLimits();
+    expect(limits['example.com'].daily.limit).toBe(10);
+    expect(limits['example.com'].enabled).toBe(true);
+    expect(limits['other.com'].daily.limit).toBe(5);
+  });
+
+  test('checkLimitWarnings does not throw for legacy numeric limit', async () => {
+    mockStorage({
+      limits: { 'example.com': 10 },
+      visits: {},
+      notificationPreferences: { enabled: false, types: {}, quietHours: { enabled: false }, maxPerDay: 5 },
+    });
+    await expect(checkLimitWarnings('example.com', 8)).resolves.not.toThrow();
+    await expect(checkLimitWarnings('example.com', 10)).resolves.not.toThrow();
+  });
+
+  test('calculateDailyFocusScore does not throw for legacy numeric limit', async () => {
+    const today = new Date().toISOString().split('T')[0];
+    mockStorage({
+      visits: { [today]: { 'example.com': { count: 5, lastVisit: Date.now(), timestamps: [], subpaths: {} } } },
+      limits: { 'example.com': 10 },
+      overallStreak: { current: 1, best: 1 },
+    });
+    await expect(calculateDailyFocusScore(today)).resolves.not.toThrow();
+    const score = await calculateDailyFocusScore(today);
+    expect(typeof score).toBe('number');
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+
+  test('getFocusScoreBreakdown does not throw for legacy numeric limit', async () => {
+    const today = new Date().toISOString().split('T')[0];
+    mockStorage({
+      visits: { [today]: { 'example.com': { count: 12, lastVisit: Date.now(), timestamps: [], subpaths: {} } } },
+      limits: { 'example.com': 10 },
+      overallStreak: { current: 0, best: 0 },
+    });
+    await expect(getFocusScoreBreakdown(today)).resolves.not.toThrow();
+  });
+
+  test('storage streak helpers handle legacy numeric limit without throw', async () => {
+    const { calculateLimitStreak, calculateOverallStreak } = await import('../src/background/storage.js');
+    const today = new Date().toISOString().split('T')[0];
+    mockStorage({
+      visits: { [today]: { 'example.com': { count: 5, lastVisit: Date.now(), timestamps: [], subpaths: {} } } },
+      limits: { 'example.com': 10 },
+      streaks: {},
+      overallStreak: { current: 0, best: 0 },
+    });
+    await expect(calculateLimitStreak('example.com')).resolves.not.toThrow();
+    await expect(calculateOverallStreak()).resolves.not.toThrow();
+  });
+});
+
+describe('Service worker listener single registration (Task 0.2)', () => {
+  test('initializeTracking appears exactly once statically in background/index.js', async () => {
+    const fs = await import('fs');
+    const path = await import('path');
+    const content = fs.readFileSync(path.join(process.cwd(), 'src/background/index.js'), 'utf8');
+    const matches = content.match(/initializeTracking\(\)/g) || [];
+    // Should be exactly one top-level call (not inside onInstalled)
+    expect(matches.length).toBe(1);
+    // Ensure not inside onInstalled handler
+    const onInstalledSection = content.split('chrome.runtime.onInstalled.addListener')[1]?.split('});')[0] || '';
+    expect(onInstalledSection).not.toMatch(/initializeTracking/);
+  });
+});


### PR DESCRIPTION
Closes #20, #21, #22

- **#20 (0.2)**: Remove duplicate SW listeners from onInstalled (keep seeding only), top-level only; normalize legacy numeric limits at storage getter (getLimits + streak helpers) and in focus-score/notifications; add regression tests (7 suites, 126 tests) for numeric limits and single initializeTracking assertion
  - Verify: grep -c initializeTracking src/background/index.js == 1 (plus import), npm test -- --ci passes at ≥ 0.1 rate, lint clean

- **#21 (0.3)**: Make build deterministic — build.js stamps dist/manifest.json version_name via git hash, package.json build no longer mutates tracked manifest
  - Verify: npm run build && git status --porcelain shows no manifest change, dist/manifest.json carries version_name

- **#22 (0.4)**: Add landing-page quality gate job to CI (lint, format:check, build) with cache; format landing sources so job passes
  - Verify: CI shows landing job green, npm test -- --ci green at ≥ recorded rate