### PR TITLE
P2 Wave 13: react-router 6→7 and lucide 0.x→1.x

### DIFF
--- a/landing-page/package-lock.json
+++ b/landing-page/package-lock.json
@@ -8,10 +8,10 @@
       "name": "focusbear-landing-page",
       "version": "0.2.0",
       "dependencies": {
-        "lucide-react": "^0.460.0",
+        "lucide-react": "^1.38.0",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
-        "react-router-dom": "^6.30.6",
+        "react-router-dom": "^7.18.3",
         "yet-another-react-lightbox": "^3.32.2"
       },
       "devDependencies": {
@@ -1050,15 +1050,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@remix-run/router": {
-      "version": "1.23.4",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.4.tgz",
-      "integrity": "sha512-q7j5geK7xs3UJSdm9/iytUNclBnLmYx1EnSeCFXHPeutdqgIMeFeHtUZgS3EhlKxdBEAu8OwtJCwmLrEzpSs7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -2161,6 +2152,19 @@
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -4216,12 +4220,12 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "0.460.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.460.0.tgz",
-      "integrity": "sha512-BVtq/DykVeIvRTJvRAgCsOwaGL8Un3Bxh8MbDxMhEWlZay3T4IpEKDEpwt5KZ0KJMHzgm6jrltxlT5eXOWXDHg==",
+      "version": "1.38.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.38.0.tgz",
+      "integrity": "sha512-xZCyBd/wiVUDactoCc+42TjL0aB7EBOXsuX+tjz+W/sGzw2KhHpL1NOH3FIaVUcpimvUBpIYfz34Ofj9S5JEzQ==",
       "license": "ISC",
       "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/math-intrinsics": {
@@ -5383,35 +5387,41 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.30.6",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.6.tgz",
-      "integrity": "sha512-5HfK7k5im7LTOB0EqCQmfvy4C13G92Ssj1VTmouTK3AJvyjKTnFuCV0vcMAD/JS+JC4DvDIBRrlAeJIFjh5VWg==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.3.tgz",
+      "integrity": "sha512-gyXgtdr5uACJ5b1Q4udzjVV+tb/rlHIMJKuJ0e89R4Kzgz47z/rgP0dIKxktqIEUhDHluGTPJJH/wRha7CyqsA==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.4"
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.30.6",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.6.tgz",
-      "integrity": "sha512-0RHKZz7wwffvkU+2MFVT2NnjK44ssLEV+m0CAJaS2Ksmorrwj7WxH00jO0SOCW26/tINUnJHToXblDs33I38YQ==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.3.tgz",
+      "integrity": "sha512-ytVbyBBM7vMfRCam25r0WMhSVSom909A8p+8m0/f1w853dz/xfFu6etAT2SEbVoSnI+ZoPRDqIsQXVT89gp7kg==",
       "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.23.4",
-        "react-router": "6.30.6"
+        "react-router": "7.18.3"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     },
     "node_modules/read-cache": {
@@ -5670,6 +5680,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/landing-page/package.json
+++ b/landing-page/package.json
@@ -13,10 +13,10 @@
     "format:check": "prettier --check \"src/**/*.{js,jsx,css}\""
   },
   "dependencies": {
-    "lucide-react": "^0.460.0",
+    "lucide-react": "^1.38.0",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",
-    "react-router-dom": "^6.30.6",
+    "react-router-dom": "^7.18.3",
     "yet-another-react-lightbox": "^3.32.2"
   },
   "devDependencies": {

--- a/landing-page/src/components/Footer.jsx
+++ b/landing-page/src/components/Footer.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { Github, Zap, Heart } from 'lucide-react';
+import { Code, Zap, Heart } from 'lucide-react';
 import { footerContent } from '../data/footer';
 
 function Footer() {
@@ -32,7 +32,7 @@ function Footer() {
                   aria-label={link.ariaLabel}
                 >
                   {link.id === 'github' && (
-                    <Github className="w-4 h-4" aria-hidden="true" />
+                    <Code className="w-4 h-4" aria-hidden="true" />
                   )}
                   {link.label}
                 </a>

--- a/landing-page/src/components/Hero.jsx
+++ b/landing-page/src/components/Hero.jsx
@@ -1,4 +1,4 @@
-import { Chrome } from 'lucide-react';
+import { Globe } from 'lucide-react';
 import { heroContent } from '../data/hero';
 
 function Hero() {
@@ -37,7 +37,7 @@ function Hero() {
               className="btn-primary text-lg px-8 py-4 flex items-center gap-3"
               aria-label={heroContent.ctaButton.ariaLabel}
             >
-              <Chrome className="w-6 h-6" aria-hidden="true" />
+              <Globe className="w-6 h-6" aria-hidden="true" />
               {heroContent.ctaButton.text}
             </a>
           </div>

--- a/landing-page/src/pages/Landing.jsx
+++ b/landing-page/src/pages/Landing.jsx
@@ -1,7 +1,7 @@
 import Hero from '../components/Hero';
 import Features from '../components/Features';
 import Screenshots from '../components/Screenshots';
-import { Chrome } from 'lucide-react';
+import { Globe } from 'lucide-react';
 import { heroContent } from '../data/hero';
 
 function Landing() {
@@ -28,7 +28,7 @@ function Landing() {
             className="btn-primary text-lg px-8 py-4 inline-flex items-center gap-3"
             aria-label={heroContent.ctaButton.ariaLabel}
           >
-            <Chrome className="w-6 h-6" aria-hidden="true" />
+            <Globe className="w-6 h-6" aria-hidden="true" />
             Get FocusBear Now
           </a>
         </div>


### PR DESCRIPTION
Closes #38, #39

- **2.11 react-router-dom 6.30.6→7.18.3** (major spike per https://reactrouter.com/upgrading/v6): bump `react-router-dom@^7.18.3`, verify BrowserRouter/Routes/Route/Lazy still work (landing build green, 1862 modules), no breaking route API used here
- **2.12 lucide-react 0.460.0→1.38.0** (major): 6 import sites checked — `Github` removed in 1.x (brand icon) → replaced with `Code` in Footer.jsx, `Chrome` removed → replaced with `Globe` in Hero.jsx/Landing.jsx, other icons (`Shield, BarChart3, Timer, TrendingUp, Menu, X, Zap, Heart, ArrowLeft`) still valid in 1.x; build now green (1862 modules, 257k vendor), lint 0 warnings

Verify: `cd landing-page && npm run build` green, `npm run lint -- --max-warnings 0` 0, `npm test -- --ci` 136 pass root, manual preview Landing + Privacy renders

Depends on #37 — P2 (M2)