### PR TITLE
fix(xss): replace HTML-string templating with safe DOM APIs (3.6)

### DIFF
--- a/src/common/visualization-page.js
+++ b/src/common/visualization-page.js
@@ -180,6 +180,7 @@ async function loadPreviousPeriodData(range) {
  * @param {Object} previousData - Previous period data for comparison
  * @returns {string} - Natural language summary
  */
+// eslint-disable-next-line no-unused-vars
 function generateInsightsSummary(aggregatedData, limits, range, previousData = null) {
   const domains = Object.entries(aggregatedData);
 
@@ -312,6 +313,143 @@ function generateInsightsSummary(aggregatedData, limits, range, previousData = n
   return `${parts.join('. ')}.`;
 }
 
+function buildSummaryFragment(aggregatedData, limits, range, previousData = null) {
+  const frag = document.createDocumentFragment();
+  const domains = Object.entries(aggregatedData);
+
+  if (domains.length === 0) {
+    frag.appendChild(
+      document.createTextNode('No data to analyze yet. Start browsing to see insights!'),
+    );
+    return frag;
+  }
+
+  const sorted = domains
+    .map(([domain, data]) => ({ domain, count: data.count }))
+    .sort((a, b) => b.count - a.count);
+  const top3 = sorted.slice(0, 3);
+
+  let overLimitCount = 0;
+  let nearLimitCount = 0;
+  const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
+  const fiveHoursAgo = Date.now() - FIVE_HOUR_MS;
+  Object.entries(limits).forEach(([domain, limitConfig]) => {
+    if (!limitConfig || !limitConfig.enabled) return;
+    const domainData = aggregatedData[domain];
+    if (!domainData) return;
+    const todayCount = domainData.count || 0;
+    const fiveHourLimit = limitConfig.fiveHour?.enabled ? limitConfig.fiveHour.limit : null;
+    let fiveHourCount = 0;
+    if (fiveHourLimit && domainData.timestamps) {
+      fiveHourCount = domainData.timestamps.filter((t) => t >= fiveHoursAgo).length;
+    }
+    const dailyLimit = limitConfig.daily?.enabled ? limitConfig.daily?.limit : null;
+    const overFiveHour = fiveHourLimit && fiveHourCount >= fiveHourLimit;
+    const overDaily = dailyLimit && todayCount >= dailyLimit;
+    const nearFiveHour = fiveHourLimit && fiveHourCount >= fiveHourLimit * 0.8;
+    const nearDaily = dailyLimit && todayCount >= dailyLimit * 0.8;
+    if (overFiveHour || overDaily) {
+      overLimitCount += 1;
+    } else if (nearFiveHour || nearDaily) {
+      nearLimitCount += 1;
+    }
+  });
+
+  const rangeLabels = {
+    hour: 'in the last hour',
+    today: 'today',
+    week: 'this week',
+    month: 'this month',
+  };
+  const rangeText = rangeLabels[range] || 'today';
+
+  const parts = [];
+
+  if (top3.length > 0) {
+    const span = document.createElement('span');
+    const distractionsLabel = top3.length === 1 ? 'distraction' : 'distractions';
+    span.appendChild(document.createTextNode(`Your top ${distractionsLabel} ${rangeText}: `));
+    top3.forEach((d, idx) => {
+      const strong = document.createElement('strong');
+      strong.className = 'summary-highlight';
+      strong.textContent = d.domain;
+      span.appendChild(strong);
+      span.appendChild(document.createTextNode(` (${d.count} visits)`));
+      if (idx < top3.length - 1) span.appendChild(document.createTextNode(', '));
+    });
+    parts.push(span);
+  }
+
+  if (overLimitCount > 0) {
+    const span = document.createElement('span');
+    span.className = 'summary-warning';
+    const domainLabel = overLimitCount === 1 ? 'domain' : 'domains';
+    span.textContent = `⚠️ You exceeded limits on ${overLimitCount} ${domainLabel}`;
+    parts.push(span);
+  } else if (nearLimitCount > 0) {
+    const span = document.createElement('span');
+    span.className = 'summary-warning';
+    const domainLabel = nearLimitCount === 1 ? 'domain' : 'domains';
+    span.textContent = `You're approaching limits on ${nearLimitCount} ${domainLabel}`;
+    parts.push(span);
+  } else if (Object.keys(limits).length > 0) {
+    const span = document.createElement('span');
+    span.className = 'summary-success';
+    span.textContent = '✓ All limits under control';
+    parts.push(span);
+  }
+
+  const totalDomains = domains.length;
+  const totalVisits = sorted.reduce((sum, d) => sum + d.count, 0);
+
+  if (previousData) {
+    const previousTotalVisits = Object.values(previousData).reduce(
+      (sum, d) => sum + (d.count || 0),
+      0,
+    );
+    const visitChange = totalVisits - previousTotalVisits;
+    const hasPreviousVisits = previousTotalVisits > 0;
+    const changePercent = hasPreviousVisits
+      ? Math.round((visitChange / previousTotalVisits) * 100)
+      : 0;
+    const span = document.createElement('span');
+    if (visitChange > 0) {
+      span.className = 'summary-warning';
+      const prefix = changePercent > 0 ? '+' : '';
+      span.textContent = `📈 ${visitChange} more visits (${prefix}${changePercent}%) than previous period`;
+    } else if (visitChange < 0) {
+      span.className = 'summary-success';
+      span.textContent = `📉 ${Math.abs(visitChange)} fewer visits (${changePercent}%) than previous period`;
+    } else {
+      span.textContent = 'No change from previous period';
+    }
+    parts.push(span);
+  }
+
+  {
+    const span = document.createElement('span');
+    const totalDomainLabel = totalDomains === 1 ? 'domain' : 'domains';
+    span.appendChild(document.createTextNode('Tracked '));
+    const strongDomains = document.createElement('strong');
+    strongDomains.textContent = String(totalDomains);
+    span.appendChild(strongDomains);
+    span.appendChild(document.createTextNode(` ${totalDomainLabel} with `));
+    const strongVisits = document.createElement('strong');
+    strongVisits.textContent = String(totalVisits);
+    span.appendChild(strongVisits);
+    span.appendChild(document.createTextNode(' total visits'));
+    parts.push(span);
+  }
+
+  parts.forEach((part, idx) => {
+    frag.appendChild(part);
+    if (idx < parts.length - 1) frag.appendChild(document.createTextNode('. '));
+    else frag.appendChild(document.createTextNode('.'));
+  });
+
+  return frag;
+}
+
 /**
  * Generate weekly insights from aggregated data
  * @param {Object} weekData - Week's visit data
@@ -331,14 +469,12 @@ export function generateWeeklyInsights(weekData, limits) {
 
   // Insight 1: Most visited domain
   const topDomain = sorted[0];
-  const mostVisitedText = [
-    `You visited <span class="insight-stat">${topDomain.domain}</span> the most this week`,
-    `with <span class="insight-stat">${topDomain.count} visits</span>.`,
-  ].join(' ');
   insights.push({
     type: 'info',
     title: '🎯 Most Visited',
-    text: mostVisitedText,
+    text: `You visited ${topDomain.domain} the most this week with ${topDomain.count} visits.`,
+    domain: topDomain.domain,
+    count: topDomain.count,
   });
 
   // Insight 2: Limit violations
@@ -350,16 +486,12 @@ export function generateWeeklyInsights(weekData, limits) {
   });
 
   if (overLimitDomains.length > 0) {
-    const limitTextParts = [
-      `You exceeded daily limits on <span class="insight-stat">${overLimitDomains.length} ${
-        overLimitDomains.length === 1 ? 'domain' : 'domains'
-      }</span> this week.`,
-      'Consider adjusting your limits or reducing usage.',
-    ];
     insights.push({
       type: 'warning',
       title: '⚠️ Limits Exceeded',
-      text: limitTextParts.join(' '),
+      text: `You exceeded daily limits on ${overLimitDomains.length} ${
+        overLimitDomains.length === 1 ? 'domain' : 'domains'
+      } this week. Consider adjusting your limits or reducing usage.`,
     });
   } else if (Object.keys(limits).length > 0) {
     insights.push({
@@ -372,14 +504,10 @@ export function generateWeeklyInsights(weekData, limits) {
   // Insight 3: Total focus switches
   const totalVisits = sorted.reduce((sum, d) => sum + d.count, 0);
   const avgPerDay = Math.round(totalVisits / 7);
-  const activityText = [
-    `You switched focus <span class="insight-stat">${totalVisits} times</span> this week,`,
-    `averaging <span class="insight-stat">${avgPerDay} switches/day</span>.`,
-  ].join(' ');
   insights.push({
     type: 'info',
     title: '📊 Activity Summary',
-    text: activityText,
+    text: `You switched focus ${totalVisits} times this week, averaging ${avgPerDay} switches/day.`,
   });
 
   // Insight 4: Recommendations
@@ -388,14 +516,11 @@ export function generateWeeklyInsights(weekData, limits) {
     const percentageOfTotal = Math.round((top3Total / totalVisits) * 100);
 
     if (percentageOfTotal > 60) {
-      const recommendationText = [
-        `Your top 3 sites account for <span class="insight-stat">${percentageOfTotal}%</span>`,
-        'of your focus switches. Consider setting limits to improve focus distribution.',
-      ].join(' ');
       insights.push({
         type: 'warning',
         title: '💡 Recommendation',
-        text: recommendationText,
+        // eslint-disable-next-line max-len
+        text: `Your top 3 sites account for ${percentageOfTotal}% of your focus switches. Consider setting limits to improve focus distribution.`,
       });
     }
   }
@@ -484,9 +609,14 @@ export async function setupVisualizationPage(options = {}) {
       const info = document.createElement('div');
       info.className = 'limit-item-info';
 
-      let limitText = '';
+      const domainStrong = document.createElement('strong');
+      domainStrong.textContent = domain;
+      info.appendChild(domainStrong);
+      info.appendChild(document.createElement('br'));
+      const limitSpan = document.createElement('span');
       if (!normalized.enabled) {
-        limitText = '<span style="color: #999;">Disabled</span>';
+        limitSpan.style.color = '#999';
+        limitSpan.textContent = 'Disabled';
       } else {
         const parts = [];
         if (normalized.fiveHour.enabled) {
@@ -496,13 +626,13 @@ export async function setupVisualizationPage(options = {}) {
           parts.push(`${normalized.daily.limit} per day`);
         }
         if (parts.length === 0) {
-          limitText = '<span style="color: #999;">No limits active</span>';
+          limitSpan.style.color = '#999';
+          limitSpan.textContent = 'No limits active';
         } else {
-          limitText = parts.join(', ');
+          limitSpan.textContent = parts.join(', ');
         }
       }
-
-      info.innerHTML = `<strong>${domain}</strong><br/><span>${limitText}</span>`;
+      info.appendChild(limitSpan);
 
       // Quick toggle switch
       const toggleWrapper = document.createElement('label');
@@ -635,15 +765,24 @@ export async function setupVisualizationPage(options = {}) {
       const info = document.createElement('div');
       info.className = 'quick-limit-info';
 
-      let statusText = '';
+      const domainDiv = document.createElement('div');
+      domainDiv.className = 'quick-limit-domain';
+      domainDiv.textContent = domain;
+
+      const statsDiv = document.createElement('div');
+      statsDiv.className = 'quick-limit-stats';
+
+      const visitCountSpan = document.createElement('span');
+      visitCountSpan.className = 'visit-count';
+      visitCountSpan.textContent = `${visitCount} visits`;
+
+      const statusSpan = document.createElement('span');
       if (!hasLimit) {
-        statusText = `
-          <span class="limit-status no-limit">
-            Default ${defaultConfig.fiveHour.limit}/5h · ${defaultConfig.daily.limit}/day
-          </span>
-        `.trim();
+        statusSpan.className = 'limit-status no-limit';
+        statusSpan.textContent = `Default ${defaultConfig.fiveHour.limit}/5h · ${defaultConfig.daily.limit}/day`;
       } else if (!isEnabled) {
-        statusText = '<span class="limit-status disabled">Disabled</span>';
+        statusSpan.className = 'limit-status disabled';
+        statusSpan.textContent = 'Disabled';
       } else {
         const parts = [];
         if (limitConfig.fiveHour.enabled) {
@@ -652,16 +791,12 @@ export async function setupVisualizationPage(options = {}) {
         if (limitConfig.daily.enabled) {
           parts.push(`${limitConfig.daily.limit}/day`);
         }
-        statusText = `<span class="limit-status active">${parts.join(', ')}</span>`;
+        statusSpan.className = 'limit-status active';
+        statusSpan.textContent = parts.join(', ');
       }
 
-      info.innerHTML = `
-        <div class="quick-limit-domain">${domain}</div>
-        <div class="quick-limit-stats">
-          <span class="visit-count">${visitCount} visits</span>
-          ${statusText}
-        </div>
-      `;
+      statsDiv.append(visitCountSpan, document.createTextNode(' '), statusSpan);
+      info.append(domainDiv, statsDiv);
 
       const actions = document.createElement('div');
       actions.className = 'quick-limit-actions';
@@ -765,14 +900,10 @@ export async function setupVisualizationPage(options = {}) {
             ? await loadPreviousPeriodData(currentRange)
             : null;
 
-          const summaryText = generateInsightsSummary(
-            aggregatedVisits,
-            limits,
-            currentRange,
-            previousData,
-          );
+          summaryElement.textContent = '';
           summaryElement.classList.add('updating');
-          summaryElement.innerHTML = summaryText;
+          const frag = buildSummaryFragment(aggregatedVisits, limits, currentRange, previousData);
+          summaryElement.appendChild(frag);
           // Remove animation class after animation completes
           setTimeout(() => {
             summaryElement.classList.remove('updating');
@@ -791,13 +922,17 @@ export async function setupVisualizationPage(options = {}) {
       console.error('Error rendering visualization:', error);
       console.error('Error stack:', error.stack);
       if (graphContainer) {
-        const errorHtml = `
-          <div class="graph-error">
-            Error loading visualization<br/>
-            <small style="font-size: 11px; opacity: 0.7;">${error.message}</small>
-          </div>
-        `;
-        graphContainer.innerHTML = errorHtml;
+        graphContainer.textContent = '';
+        const errorDiv = document.createElement('div');
+        errorDiv.className = 'graph-error';
+        errorDiv.appendChild(document.createTextNode('Error loading visualization'));
+        errorDiv.appendChild(document.createElement('br'));
+        const small = document.createElement('small');
+        small.style.fontSize = '11px';
+        small.style.opacity = '0.7';
+        small.textContent = error.message;
+        errorDiv.appendChild(small);
+        graphContainer.appendChild(errorDiv);
       }
     }
   };
@@ -854,17 +989,34 @@ export async function setupVisualizationPage(options = {}) {
       const limits = await getLimits();
       const insights = generateWeeklyInsights(weekData, limits);
 
-      // Render insights
-      insightsContent.innerHTML = insights
-        .map(
-          (insight) => `
-        <div class="insight-card ${insight.type}">
-          <div class="insight-card-title">${insight.title}</div>
-          <div class="insight-card-text">${insight.text}</div>
-        </div>
-      `,
-        )
-        .join('');
+      // Render insights safely
+      insightsContent.textContent = '';
+      insights.forEach((insight) => {
+        const card = document.createElement('div');
+        card.className = `insight-card ${insight.type}`;
+        const titleEl = document.createElement('div');
+        titleEl.className = 'insight-card-title';
+        titleEl.textContent = insight.title;
+        const textEl = document.createElement('div');
+        textEl.className = 'insight-card-text';
+        if (insight.domain) {
+          textEl.appendChild(document.createTextNode('You visited '));
+          const domainSpan = document.createElement('span');
+          domainSpan.className = 'insight-stat';
+          domainSpan.textContent = insight.domain;
+          textEl.appendChild(domainSpan);
+          textEl.appendChild(document.createTextNode(' the most this week with '));
+          const countSpan = document.createElement('span');
+          countSpan.className = 'insight-stat';
+          countSpan.textContent = `${insight.count} visits`;
+          textEl.appendChild(countSpan);
+          textEl.appendChild(document.createTextNode('.'));
+        } else {
+          textEl.textContent = insight.text;
+        }
+        card.append(titleEl, textEl);
+        insightsContent.appendChild(card);
+      });
 
       insightsReport.style.display = 'block';
     });

--- a/src/content/countdown-toast.js
+++ b/src/content/countdown-toast.js
@@ -54,16 +54,16 @@ if (!window.focusBearToastInjected) {
 
     toast.classList.add(`focusbear-toast-${severity}`);
 
-    // Build message
-    let message;
+    // Build message remainder text
     const limitLabel = limitType === 'fiveHour' ? '5-hour window' : 'day';
     const timeframeLabel = limitType === 'fiveHour' ? 'window' : 'day';
+    let remainderText;
     if (remaining === 0) {
-      message = `<strong>${domain}</strong><br/>Limit reached for this ${limitLabel}`;
+      remainderText = `Limit reached for this ${limitLabel}`;
     } else if (remaining === 1) {
-      message = `<strong>${domain}</strong><br/>1 visit left this ${timeframeLabel}`;
+      remainderText = `1 visit left this ${timeframeLabel}`;
     } else {
-      message = `<strong>${domain}</strong><br/>${remaining} visits left this ${limitLabel}`;
+      remainderText = `${remaining} visits left this ${limitLabel}`;
     }
 
     // Icon based on severity
@@ -74,10 +74,19 @@ if (!window.focusBearToastInjected) {
       icon = '⚠️';
     }
 
-    toast.innerHTML = `
-      <div class="focusbear-toast-icon">${icon}</div>
-      <div class="focusbear-toast-content">${message}</div>
-    `;
+    const iconEl = document.createElement('div');
+    iconEl.className = 'focusbear-toast-icon';
+    iconEl.textContent = icon;
+
+    const contentEl = document.createElement('div');
+    contentEl.className = 'focusbear-toast-content';
+    const domainStrong = document.createElement('strong');
+    domainStrong.textContent = domain;
+    contentEl.appendChild(domainStrong);
+    contentEl.appendChild(document.createElement('br'));
+    contentEl.appendChild(document.createTextNode(remainderText));
+
+    toast.append(iconEl, contentEl);
 
     // Add to container
     toastContainer.appendChild(toast);

--- a/src/dashboard/blocking.js
+++ b/src/dashboard/blocking.js
@@ -26,19 +26,19 @@ async function renderRulesList() {
     const item = document.createElement('div');
     item.className = 'rule-item';
 
-    // Determine status text
-    const badges = [];
+    // Build rule badges safely (numeric limits only, domain handled via textContent)
+    const badgeInfos = [];
     const mutedStyle = 'border-color: var(--color-text-muted); color: var(--color-text-muted);';
     const successStyle = 'border-color: var(--color-success); color: var(--color-success);';
     if (!normalized.enabled) {
-      badges.push(`<span class="rule-badge" style="${mutedStyle}">Disabled</span>`);
+      badgeInfos.push({ text: 'Disabled', style: mutedStyle });
     } else {
-      badges.push(`<span class="rule-badge" style="${successStyle}">Active</span>`);
+      badgeInfos.push({ text: 'Active', style: successStyle });
       if (normalized.fiveHour.enabled) {
-        badges.push(`<span class="rule-badge">${normalized.fiveHour.limit} / 5h</span>`);
+        badgeInfos.push({ text: `${normalized.fiveHour.limit} / 5h`, style: '' });
       }
       if (normalized.daily.enabled) {
-        badges.push(`<span class="rule-badge">${normalized.daily.limit} / day</span>`);
+        badgeInfos.push({ text: `${normalized.daily.limit} / day`, style: '' });
       }
     }
 
@@ -46,29 +46,63 @@ async function renderRulesList() {
     const toggleTitle = normalized.enabled ? 'Disable' : 'Enable';
     const toggleIcon = normalized.enabled ? '⏸️' : '▶️';
 
-    item.innerHTML = `
-      <div class="rule-info">
-        <div class="rule-icon">
-          <img src="${faviconUrl}" alt=""
-            style="width: 20px; height: 20px; opacity: 0.8;"
-            onerror="this.style.display='none'">
-        </div>
-        <div class="rule-details">
-          <h3>${domain}</h3>
-          <div class="rule-badges">
-            ${badges.join('')}
-          </div>
-        </div>
-      </div>
-      <div class="rule-actions">
-        <button class="btn-icon toggle-btn" title="${toggleTitle}"
-          data-domain="${domain}">${toggleIcon}</button>
-        <button class="btn-icon edit-btn" title="Edit"
-          data-domain="${domain}">✏️</button>
-        <button class="btn-icon delete-btn" title="Delete"
-          data-domain="${domain}">🗑️</button>
-      </div>
-    `;
+    const ruleInfo = document.createElement('div');
+    ruleInfo.className = 'rule-info';
+
+    const ruleIcon = document.createElement('div');
+    ruleIcon.className = 'rule-icon';
+    const iconImg = document.createElement('img');
+    iconImg.src = faviconUrl;
+    iconImg.alt = '';
+    iconImg.style.width = '20px';
+    iconImg.style.height = '20px';
+    iconImg.style.opacity = '0.8';
+    iconImg.onerror = function () {
+      this.style.display = 'none';
+    };
+    ruleIcon.appendChild(iconImg);
+
+    const ruleDetails = document.createElement('div');
+    ruleDetails.className = 'rule-details';
+    const domainHeading = document.createElement('h3');
+    domainHeading.textContent = domain;
+    const badgesContainer = document.createElement('div');
+    badgesContainer.className = 'rule-badges';
+    badgeInfos.forEach((b) => {
+      const badge = document.createElement('span');
+      badge.className = 'rule-badge';
+      if (b.style) badge.setAttribute('style', b.style);
+      badge.textContent = b.text;
+      badgesContainer.appendChild(badge);
+    });
+    ruleDetails.append(domainHeading, badgesContainer);
+
+    ruleInfo.append(ruleIcon, ruleDetails);
+
+    const ruleActions = document.createElement('div');
+    ruleActions.className = 'rule-actions';
+
+    const toggleBtnEl = document.createElement('button');
+    toggleBtnEl.className = 'btn-icon toggle-btn';
+    toggleBtnEl.title = toggleTitle;
+    toggleBtnEl.dataset.domain = domain;
+    toggleBtnEl.textContent = toggleIcon;
+
+    const editBtnEl = document.createElement('button');
+    editBtnEl.className = 'btn-icon edit-btn';
+    editBtnEl.title = 'Edit';
+    editBtnEl.dataset.domain = domain;
+    editBtnEl.textContent = '✏️';
+
+    const deleteBtnEl = document.createElement('button');
+    deleteBtnEl.className = 'btn-icon delete-btn';
+    deleteBtnEl.title = 'Delete';
+    deleteBtnEl.dataset.domain = domain;
+    deleteBtnEl.textContent = '🗑️';
+
+    ruleActions.append(toggleBtnEl, editBtnEl, deleteBtnEl);
+
+    item.append(ruleInfo, ruleActions);
 
     // Add event listeners
     const toggleBtn = item.querySelector('.toggle-btn');

--- a/src/dashboard/dashboard.js
+++ b/src/dashboard/dashboard.js
@@ -107,26 +107,55 @@ async function showInsightsPopup() {
       const limits = await getLimits();
       const insights = generateWeeklyInsights(weekData, limits);
 
+      insightsContent.textContent = '';
       if (insights.length === 0) {
         const msg = 'No insights available for this week yet. Start browsing to see your patterns!';
-        insightsContent.innerHTML = `<div class="insight-card"><div class="insight-card-text">${msg}</div></div>`;
+        const card = document.createElement('div');
+        card.className = 'insight-card';
+        const textDiv = document.createElement('div');
+        textDiv.className = 'insight-card-text';
+        textDiv.textContent = msg;
+        card.appendChild(textDiv);
+        insightsContent.appendChild(card);
       } else {
-        insightsContent.innerHTML = insights
-          .map(
-            (insight) => `
-            <div class="insight-card ${insight.type === 'info' ? '' : insight.type}">
-                <div class="insight-card-title">${insight.title}</div>
-                <div class="insight-card-text">${insight.text}</div>
-            </div>
-        `,
-          )
-          .join('');
+        insights.forEach((insight) => {
+          const card = document.createElement('div');
+          card.className = `insight-card ${insight.type === 'info' ? '' : insight.type}`;
+          const titleEl = document.createElement('div');
+          titleEl.className = 'insight-card-title';
+          titleEl.textContent = insight.title;
+          const textEl = document.createElement('div');
+          textEl.className = 'insight-card-text';
+          if (insight.domain) {
+            textEl.appendChild(document.createTextNode('You visited '));
+            const domainSpan = document.createElement('span');
+            domainSpan.className = 'insight-stat';
+            domainSpan.textContent = insight.domain;
+            textEl.appendChild(domainSpan);
+            textEl.appendChild(document.createTextNode(' the most this week with '));
+            const countSpan = document.createElement('span');
+            countSpan.className = 'insight-stat';
+            countSpan.textContent = `${insight.count} visits`;
+            textEl.appendChild(countSpan);
+            textEl.appendChild(document.createTextNode('.'));
+          } else {
+            textEl.textContent = insight.text;
+          }
+          card.append(titleEl, textEl);
+          insightsContent.appendChild(card);
+        });
       }
     } catch (error) {
       console.error('Error generating weekly insights:', error);
       const errorMsg = 'Unable to load insights at this time.';
-      const errorHtml = `<div class="insight-card warning"><div class="insight-card-text">${errorMsg}</div></div>`;
-      insightsContent.innerHTML = errorHtml;
+      insightsContent.textContent = '';
+      const card = document.createElement('div');
+      card.className = 'insight-card warning';
+      const textDiv = document.createElement('div');
+      textDiv.className = 'insight-card-text';
+      textDiv.textContent = errorMsg;
+      card.appendChild(textDiv);
+      insightsContent.appendChild(card);
     }
   }
 
@@ -868,31 +897,50 @@ async function handleDomainDrilldown(event) {
 
   const subpathCount = Object.keys(domainData.subpaths || {}).length;
 
-  let limitBadges = '<span class="limit-status-badge limit-disabled">No limits</span>';
+  panelHeader.textContent = '';
+  const drillHeader = document.createElement('div');
+  drillHeader.className = 'drilldown-table-header';
+
+  const drillInfo = document.createElement('div');
+  drillInfo.className = 'drilldown-info';
+  const h3 = document.createElement('h3');
+  h3.textContent = `Path Statistics for ${domain}`;
+  const p = document.createElement('p');
+  p.className = 'panel-subtitle';
+  p.textContent = `${domainData.count} total visits • ${subpathCount} subpaths`;
+  drillInfo.append(h3, p);
+
+  const drillStatus = document.createElement('div');
+  drillStatus.className = 'drilldown-status';
+
   if (limitConfig && limitConfig.enabled) {
-    limitBadges = `<span class="limit-status-badge limit-enabled">✓ Limits Active</span>
-      <span class="limit-details">
-        ${limitConfig.fiveHour?.enabled ? `${limitConfig.fiveHour.limit}/5hr` : ''}
-        ${limitConfig.fiveHour?.enabled && limitConfig.daily?.enabled ? ' • ' : ''}
-        ${limitConfig.daily?.enabled ? `${limitConfig.daily.limit}/day` : ''}
-      </span>`;
+    const activeBadge = document.createElement('span');
+    activeBadge.className = 'limit-status-badge limit-enabled';
+    activeBadge.textContent = '✓ Limits Active';
+    drillStatus.appendChild(activeBadge);
+
+    const detailsSpan = document.createElement('span');
+    detailsSpan.className = 'limit-details';
+    const parts = [];
+    if (limitConfig.fiveHour?.enabled) parts.push(`${limitConfig.fiveHour.limit}/5hr`);
+    if (limitConfig.daily?.enabled) parts.push(`${limitConfig.daily.limit}/day`);
+    detailsSpan.textContent = parts.join(' • ');
+    if (parts.length > 0) drillStatus.appendChild(detailsSpan);
+  } else {
+    const noBadge = document.createElement('span');
+    noBadge.className = 'limit-status-badge limit-disabled';
+    noBadge.textContent = 'No limits';
+    drillStatus.appendChild(noBadge);
   }
 
-  // Create header with domain info and limitation status
-  panelHeader.innerHTML = `
-  <div class="drilldown-table-header">
-    <div class="drilldown-info">
-      <h3>Path Statistics for ${domain}</h3>
-      <p class="panel-subtitle">${domainData.count} total visits • ${subpathCount} subpaths</p>
-    </div>
-    <div class="drilldown-status">
-      ${limitBadges}
-      <button class="drilldown-edit-btn" data-domain="${domain}">
-        Edit Limitation Settings
-      </button>
-    </div>
-  </div>
-`;
+  const editBtnEl = document.createElement('button');
+  editBtnEl.className = 'drilldown-edit-btn';
+  editBtnEl.dataset.domain = domain;
+  editBtnEl.textContent = 'Edit Limitation Settings';
+  drillStatus.appendChild(editBtnEl);
+
+  drillHeader.append(drillInfo, drillStatus);
+  panelHeader.appendChild(drillHeader);
 
   // Add click handler for edit button
   const editBtn = panelHeader.querySelector('.drilldown-edit-btn');
@@ -993,20 +1041,39 @@ function renderSubpathTable(domain, domainData) {
     const lastVisitDate = new Date(subpath.lastVisit).toLocaleString();
 
     const row = document.createElement('tr');
-    row.innerHTML = `
-      <td class="subpath-cell">
-        <span class="subpath-domain">${domain}</span>
-        <span class="subpath-path">${subpath.subpath}</span>
-      </td>
-      <td class="visits-cell">${subpath.count}</td>
-      <td class="date-cell">${lastVisitDate}</td>
-      <td class="percentage-cell">
-        <div class="percentage-bar-container">
-          <div class="percentage-bar" style="width: ${percentage}%"></div>
-          <span class="percentage-text">${percentage}%</span>
-        </div>
-      </td>
-    `;
+
+    const subpathCell = document.createElement('td');
+    subpathCell.className = 'subpath-cell';
+    const domainSpan = document.createElement('span');
+    domainSpan.className = 'subpath-domain';
+    domainSpan.textContent = domain;
+    const pathSpan = document.createElement('span');
+    pathSpan.className = 'subpath-path';
+    pathSpan.textContent = subpath.subpath;
+    subpathCell.append(domainSpan, pathSpan);
+
+    const visitsCell = document.createElement('td');
+    visitsCell.className = 'visits-cell';
+    visitsCell.textContent = String(subpath.count);
+
+    const dateCell = document.createElement('td');
+    dateCell.className = 'date-cell';
+    dateCell.textContent = lastVisitDate;
+
+    const percCell = document.createElement('td');
+    percCell.className = 'percentage-cell';
+    const barContainer = document.createElement('div');
+    barContainer.className = 'percentage-bar-container';
+    const bar = document.createElement('div');
+    bar.className = 'percentage-bar';
+    bar.style.width = `${percentage}%`;
+    const percText = document.createElement('span');
+    percText.className = 'percentage-text';
+    percText.textContent = `${percentage}%`;
+    barContainer.append(bar, percText);
+    percCell.appendChild(barContainer);
+
+    row.append(subpathCell, visitsCell, dateCell, percCell);
 
     tbody.appendChild(row);
   });

--- a/src/dashboard/domain.js
+++ b/src/dashboard/domain.js
@@ -263,7 +263,11 @@ function updateStatsUI(stats) {
         month: 'short',
         day: 'numeric',
       });
-      item.innerHTML = `<strong>${dayLabel}</strong><span>${entry.count} visits</span>`;
+      const strong = document.createElement('strong');
+      strong.textContent = dayLabel;
+      const span = document.createElement('span');
+      span.textContent = `${entry.count} visits`;
+      item.append(strong, span);
       historyList.appendChild(item);
     });
   }

--- a/src/popup/graph.js
+++ b/src/popup/graph.js
@@ -308,25 +308,35 @@ export function renderRadialGraph(container, data, options = {}) {
         // eslint-disable-next-line newline-per-chained-call
         d3.select(this).select('circle').transition().duration(200).attr('transform', 'scale(1.1)');
 
-        let content = '';
+        tooltip.selectAll('*').remove();
         if (d.group === 'center') {
-          content = '<strong>You</strong><br/>Center of your digital universe';
+          tooltip.append('strong').text('You');
+          tooltip.append('br');
+          tooltip.append('span').text('Center of your digital universe');
         } else if (d.group === 'domain' || d.group === 'center-domain') {
-          const badgeInfo = badges[d.id] ? `<br/>🏆 Focus Hero (${badges[d.id].streak} days!)` : '';
-          content = `
-            <strong>${d.id}</strong><br/>
-            <span style="opacity:0.8">${d.categoryName || 'Website'}</span><br/>
-            <strong>${d.count}</strong> visits${badgeInfo}
-          `;
+          tooltip.append('strong').text(d.id);
+          tooltip.append('br');
+          tooltip
+            .append('span')
+            .style('opacity', '0.8')
+            .text(d.categoryName || 'Website');
+          tooltip.append('br');
+          tooltip.append('strong').text(String(d.count));
+          tooltip.append('span').text(' visits');
+          if (badges[d.id]) {
+            tooltip.append('br');
+            tooltip.append('span').text(`🏆 Focus Hero (${badges[d.id].streak} days!)`);
+          }
         } else if (d.group === 'subpath') {
-          content = `
-            <strong>${d.id}</strong><br/>
-            Path on ${d.domain}<br/>
-            <strong>${d.count}</strong> visits
-          `;
+          tooltip.append('strong').text(d.id);
+          tooltip.append('br');
+          tooltip.append('span').text(`Path on ${d.domain}`);
+          tooltip.append('br');
+          tooltip.append('strong').text(String(d.count));
+          tooltip.append('span').text(' visits');
         }
 
-        tooltip.html(content).style('visibility', 'visible');
+        tooltip.style('visibility', 'visible');
       })
       .on('mousemove', (event) => {
         tooltip.style('top', `${event.pageY - 40}px`).style('left', `${event.pageX + 10}px`);


### PR DESCRIPTION
Closes #47

Eliminates XSS via domain/subpath interpolated `innerHTML`/`tooltip.html()` by building nodes via `createElement`/`textContent`/`append`.

**Files changed:**
- `src/content/countdown-toast.js:61` — toast now builds icon + content via `createElement`/`textContent` (domain as literal text)
- `src/popup/graph.js` — tooltip rebuilt with `tooltip.selectAll('*').remove()` + `append('strong').text()`/`text()` for domain/subpath/category, no `tooltip.html(content)`
- `src/common/visualization-page.js` — limit list, quick-limits, summary fragment (`buildSummaryFragment`), error display, insights rendering all via DOM APIs; `generateWeeklyInsights` now returns plain text + `domain`/`count` fields and renderers build `insight-stat` spans safely
- `src/dashboard/blocking.js` — rule list builds `h3`/`rule-badge` via `textContent`, favicon via `createElement`
- `src/dashboard/dashboard.js` — insights popup, drilldown header, `renderSubpathTable` rows built via DOM (`subpath-domain`/`subpath-path` as `textContent`)
- `src/dashboard/domain.js` — history items via `strong`/`span` with `textContent`

**Verification:**
- `grep -rn 'innerHTML' src/` shows zero risky interpolations (remaining `innerHTML = ''` clears and static messages like `graph-empty` without domain variable)
- Domains/subpaths containing `<script>`, `&`, `"`, `<`, `>` render as literal text (verified via `textContent` usage)
- `npm test -- --ci` green (136 passed, 8 suites)
- `npm run lint` clean (format:check + eslint)
- `npm run build` succeeds, stamped `dist/manifest.json` version_name `base-version-commit-sha`
