### PR TITLE
refactor(utils): unify date/time-range and limit-form controller (3.3)

### DIFF
--- a/src/background/achievements.js
+++ b/src/background/achievements.js
@@ -4,6 +4,7 @@
  */
 
 import { calculateOverallStreak } from './storage.js';
+import { getTodayKey } from '../common/date-utils.js';
 
 function getTotalVisitCount(visits) {
   return Object.values(visits).reduce((total, dayData) => {
@@ -122,7 +123,7 @@ export const ACHIEVEMENTS = {
     category: 'challenge',
     check: async () => {
       const { visits = {}, limits = {} } = await chrome.storage.local.get(['visits', 'limits']);
-      const today = new Date().toISOString().split('T')[0];
+      const today = getTodayKey();
       const todayVisits = visits[today] || {};
 
       const enabledLimits = Object.entries(limits).filter(
@@ -146,7 +147,7 @@ export const ACHIEVEMENTS = {
     category: 'challenge',
     check: async () => {
       const { visits = {} } = await chrome.storage.local.get('visits');
-      const today = new Date().toISOString().split('T')[0];
+      const today = getTodayKey();
       const todayVisits = visits[today] || {};
       const domainCount = Object.keys(todayVisits).length;
       return domainCount > 0 && domainCount <= 5;

--- a/src/background/focus-score.js
+++ b/src/background/focus-score.js
@@ -5,6 +5,8 @@
  */
 
 import { computeOverallStreakFromData, normalizeLimitConfig } from './storage.js';
+// eslint-disable-next-line object-curly-newline
+import { getDateKey, getTodayKey, getDateRange, getPreviousDates } from '../common/date-utils.js';
 
 function getDayTotalVisits(dayData = {}) {
   return Object.values(dayData).reduce((sum, visitData) => sum + (visitData.count || 0), 0);
@@ -164,7 +166,7 @@ export async function calculateAverageFocusScore(startDate, endDate) {
  * @returns {Promise<number>}
  */
 export async function getTodayFocusScore() {
-  const today = new Date().toISOString().split('T')[0];
+  const today = getTodayKey();
   const { visits, limits, streakDays } = await getStorageSnapshot();
   return calculateDailyFocusScoreWithData(today, visits, limits, streakDays);
 }
@@ -174,8 +176,10 @@ export async function getTodayFocusScore() {
  * @returns {Promise<number>}
  */
 export async function getWeeklyFocusScore() {
-  const today = new Date().toISOString().split('T')[0];
-  const weekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().split('T')[0];
+  const today = getTodayKey();
+  const weekAgoDate = new Date();
+  weekAgoDate.setDate(weekAgoDate.getDate() - 7);
+  const weekAgo = getDateKey(weekAgoDate);
   return calculateAverageFocusScore(weekAgo, today);
 }
 
@@ -190,7 +194,7 @@ export async function getFocusScoreHistory(days = 30) {
     const daysAgo = days - 1 - index;
     const date = new Date(today);
     date.setDate(date.getDate() - daysAgo);
-    return date.toISOString().split('T')[0];
+    return getDateKey(date);
   });
 
   const { visits, limits, streakDays } = await getStorageSnapshot();
@@ -266,38 +270,8 @@ export async function getFocusScoreBreakdown(date) {
   };
 }
 
-/**
- * Helper: Get previous N dates before a given date
- */
-function getPreviousDates(dateStr, count) {
-  const dates = [];
-  const date = new Date(dateStr);
-
-  for (let i = 1; i <= count; i += 1) {
-    const prevDate = new Date(date);
-    prevDate.setDate(prevDate.getDate() - i);
-    dates.push(prevDate.toISOString().split('T')[0]);
-  }
-
-  return dates;
-}
-
-/**
- * Helper: Get all dates in a range (inclusive)
- */
-function getDateRange(startDateStr, endDateStr) {
-  const dates = [];
-  const startDate = new Date(startDateStr);
-  const endDate = new Date(endDateStr);
-
-  const currentDate = new Date(startDate);
-  while (currentDate <= endDate) {
-    dates.push(currentDate.toISOString().split('T')[0]);
-    currentDate.setDate(currentDate.getDate() + 1);
-  }
-
-  return dates;
-}
+// Re-export helpers for external use (keep import compatibility)
+export { getPreviousDates, getDateRange };
 
 /**
  * Get focus score trend (improving/declining/stable)

--- a/src/background/notifications.js
+++ b/src/background/notifications.js
@@ -5,6 +5,7 @@
 
 import { getLimits, normalizeLimitConfig } from './storage.js';
 import { ACHIEVEMENTS } from './achievements.js';
+import { getTodayKey } from '../common/date-utils.js';
 
 // Notification types
 export const NOTIFICATION_TYPES = {
@@ -81,7 +82,7 @@ async function canSendNotification(type) {
 
   // Check daily limit
   const { notificationHistory = [] } = await chrome.storage.local.get('notificationHistory');
-  const today = new Date().toISOString().split('T')[0];
+  const today = getTodayKey();
   const todayNotifications = notificationHistory.filter((n) => n.date === today);
 
   if (todayNotifications.length >= preferences.maxPerDay) {
@@ -100,7 +101,7 @@ async function recordNotification(type, message) {
   const notification = {
     type,
     message,
-    date: new Date().toISOString().split('T')[0],
+    date: getTodayKey(),
     timestamp: new Date().toISOString(),
   };
 
@@ -264,7 +265,7 @@ export async function checkLimitWarnings(domain, currentCount) {
  */
 export async function showDailyEncouragement() {
   const { lastEncouragementDate } = await chrome.storage.local.get('lastEncouragementDate');
-  const today = new Date().toISOString().split('T')[0];
+  const today = getTodayKey();
 
   // Only show once per day
   if (lastEncouragementDate === today) return;

--- a/src/background/storage.js
+++ b/src/background/storage.js
@@ -41,6 +41,13 @@
  * }
  */
 
+import {
+  getTodayKey,
+  getDateKey,
+  parseDateKey,
+  aggregateVisitsInRange,
+} from '../common/date-utils.js';
+
 const defaultSettings = {
   onboardingComplete: false,
 };
@@ -50,6 +57,9 @@ const limitDefaults = {
   fiveHour: { enabled: true, limit: 10 },
   daily: { enabled: true, limit: 20 },
 };
+
+// eslint-disable-next-line object-curly-newline
+export { getTodayKey, getDateKey, parseDateKey, aggregateVisitsInRange };
 
 /**
  * Create a normalized limit config merged with defaults
@@ -74,22 +84,13 @@ export const RETENTION_DAYS = 30;
 export const MAX_TIMESTAMPS_PER_DOMAIN = 1000;
 
 /**
- * Get today's date in YYYY-MM-DD format
- * @returns {string} Date string
- */
-export function getTodayKey() {
-  const now = new Date();
-  return now.toISOString().split('T')[0];
-}
-
-/**
  * Get retention cutoff date key (YYYY-MM-DD) — entries older than this are compacted
  * @returns {string} Cutoff date key
  */
 export function getRetentionCutoffKey() {
   const d = new Date();
   d.setDate(d.getDate() - RETENTION_DAYS);
-  return d.toISOString().split('T')[0];
+  return getDateKey(d);
 }
 
 /**
@@ -428,10 +429,13 @@ export async function getVisitsInRange(startDate, endDate) {
   const visits = await getVisits();
   const result = {};
 
-  // Generate all date keys in range
+  // Generate all date keys in range (local)
   const currentDate = new Date(startDate);
-  while (currentDate <= endDate) {
-    const dateKey = currentDate.toISOString().split('T')[0];
+  const end = new Date(endDate);
+  currentDate.setHours(0, 0, 0, 0);
+  end.setHours(0, 0, 0, 0);
+  while (currentDate <= end) {
+    const dateKey = getDateKey(currentDate);
     if (visits[dateKey]) {
       result[dateKey] = visits[dateKey];
     }
@@ -456,7 +460,7 @@ export async function calculateFocusHeroBadges() {
   const dateKeys = Array.from({ length: 7 }, (_, index) => {
     const date = new Date(today);
     date.setDate(date.getDate() - index);
-    return date.toISOString().split('T')[0];
+    return getDateKey(date);
   });
 
   Object.keys(limits).forEach((domain) => {
@@ -509,8 +513,8 @@ export async function getAggregatedStats(range = 'today') {
       startDate = new Date(now.getTime() - 60 * 60 * 1000);
       break;
     case 'today': {
-      const todayKey = getTodayKey();
-      startDate = new Date(`${todayKey}T00:00:00.000Z`);
+      startDate = new Date(now);
+      startDate.setHours(0, 0, 0, 0);
       break;
     }
     case 'week':
@@ -520,48 +524,14 @@ export async function getAggregatedStats(range = 'today') {
       startDate = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
       break;
     default: {
-      const todayKey = getTodayKey();
-      startDate = new Date(`${todayKey}T00:00:00.000Z`);
+      startDate = new Date(now);
+      startDate.setHours(0, 0, 0, 0);
       break;
     }
   }
 
   const visits = await getVisits();
-  const aggregated = {};
-
-  // Aggregate visits across all dates in range
-  Object.entries(visits).forEach(([dateKey, dateVisits]) => {
-    const visitDate = new Date(dateKey);
-    if (visitDate >= startDate && visitDate <= now) {
-      Object.entries(dateVisits).forEach(([domain, domainData]) => {
-        if (!aggregated[domain]) {
-          aggregated[domain] = {
-            count: 0,
-            lastVisit: domainData.lastVisit,
-            subpaths: {},
-          };
-        }
-        aggregated[domain].count += domainData.count;
-        if (domainData.lastVisit > aggregated[domain].lastVisit) {
-          aggregated[domain].lastVisit = domainData.lastVisit;
-        }
-
-        // Aggregate subpaths
-        Object.entries(domainData.subpaths || {}).forEach(([subpath, subpathData]) => {
-          if (!aggregated[domain].subpaths[subpath]) {
-            aggregated[domain].subpaths[subpath] = {
-              count: 0,
-              lastVisit: subpathData.lastVisit,
-            };
-          }
-          aggregated[domain].subpaths[subpath].count += subpathData.count;
-          if (subpathData.lastVisit > aggregated[domain].subpaths[subpath].lastVisit) {
-            aggregated[domain].subpaths[subpath].lastVisit = subpathData.lastVisit;
-          }
-        });
-      });
-    }
-  });
+  const aggregated = aggregateVisitsInRange(visits, startDate, now);
 
   return aggregated;
 }
@@ -597,7 +567,7 @@ export async function calculateLimitStreak(domain) {
   const checkDate = new Date(today);
 
   for (let i = 0; i < 365; i += 1) {
-    const dateKey = checkDate.toISOString().split('T')[0];
+    const dateKey = getDateKey(checkDate);
     const dayVisits = visits[dateKey]?.[domain]?.count || 0;
 
     if (dayVisits <= dailyLimit) {
@@ -614,7 +584,7 @@ export async function calculateLimitStreak(domain) {
   streaks[domain] = {
     current: currentStreak,
     best: bestStreak,
-    lastCheckDate: today.toISOString().split('T')[0],
+    lastCheckDate: getDateKey(today),
   };
 
   await chrome.storage.local.set({ streaks });
@@ -656,7 +626,7 @@ export function computeOverallStreakFromData(visits = {}, rawLimits = {}, existi
   );
 
   for (let i = 0; i < 365; i += 1) {
-    const dateKey = checkDate.toISOString().split('T')[0];
+    const dateKey = getDateKey(checkDate);
     const dayVisits = visits[dateKey] || {};
 
     const allLimitsRespected = limitEntries.every(([domain, limitConfig]) => {
@@ -677,7 +647,7 @@ export function computeOverallStreakFromData(visits = {}, rawLimits = {}, existi
   return {
     current: currentStreak,
     best: bestStreak,
-    lastCheckDate: today.toISOString().split('T')[0],
+    lastCheckDate: getDateKey(today),
   };
 }
 

--- a/src/blocked/blocked.js
+++ b/src/blocked/blocked.js
@@ -1,4 +1,5 @@
 import { getTodayKey, normalizeLimitConfig } from '../background/storage.js';
+import { getNextMidnight } from '../common/date-utils.js';
 
 /**
  * FocusBear Blocked Page Script
@@ -151,11 +152,8 @@ function calculateTimeUntilReset() {
     const resetTime = new Date(now.getTime() + 5 * 60 * 60 * 1000);
     return resetTime.getTime();
   }
-  // For daily limit, reset is at midnight
-  const tomorrow = new Date(new Date());
-  tomorrow.setDate(tomorrow.getDate() + 1);
-  tomorrow.setHours(0, 0, 0, 0);
-  return tomorrow.getTime();
+  // For daily limit, reset is at local midnight (same as storage)
+  return getNextMidnight().getTime();
 }
 
 /**

--- a/src/common/date-utils.js
+++ b/src/common/date-utils.js
@@ -1,0 +1,177 @@
+/**
+ * Single local-timezone-aware date utility for FocusBear.
+ * Replaces all inline date-key usages.
+ */
+
+function pad2(n) {
+  return String(n).padStart(2, '0');
+}
+
+/**
+ * Format a Date to YYYY-MM-DD in local timezone.
+ * @param {Date} date
+ * @returns {string}
+ */
+export function getDateKey(date) {
+  const y = date.getFullYear();
+  const m = pad2(date.getMonth() + 1);
+  const d = pad2(date.getDate());
+  return `${y}-${m}-${d}`;
+}
+
+/**
+ * Get today's date key in local timezone.
+ * @returns {string}
+ */
+export function getTodayKey() {
+  return getDateKey(new Date());
+}
+
+/**
+ * Parse a YYYY-MM-DD key as a local Date at midnight.
+ * @param {string} dateKey
+ * @returns {Date}
+ */
+export function parseDateKey(dateKey) {
+  const [y, m, d] = dateKey.split('-').map(Number);
+  return new Date(y, m - 1, d);
+}
+
+/**
+ * Get the start of the given date (local midnight).
+ * @param {Date} date
+ * @returns {Date}
+ */
+export function getStartOfDay(date) {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+/**
+ * Get start of tomorrow (local midnight next day) — exact reset time for daily limits.
+ * @param {Date} [from=new Date()]
+ * @returns {Date}
+ */
+export function getNextMidnight(from = new Date()) {
+  const t = new Date(from);
+  t.setDate(t.getDate() + 1);
+  t.setHours(0, 0, 0, 0);
+  return t;
+}
+
+/**
+ * Milliseconds until next local midnight.
+ * @param {Date} [from=new Date()]
+ * @returns {number}
+ */
+export function getTimeUntilMidnight(from = new Date()) {
+  return getNextMidnight(from).getTime() - from.getTime();
+}
+
+/**
+ * Get all date keys in an inclusive range (local).
+ * @param {string} startKey - YYYY-MM-DD
+ * @param {string} endKey - YYYY-MM-DD
+ * @returns {string[]}
+ */
+export function getDateRange(startKey, endKey) {
+  const dates = [];
+  const start = parseDateKey(startKey);
+  const end = parseDateKey(endKey);
+  const cur = new Date(start);
+  while (cur <= end) {
+    dates.push(getDateKey(cur));
+    cur.setDate(cur.getDate() + 1);
+  }
+  return dates;
+}
+
+/**
+ * Get N previous dates before a given date (exclusive).
+ * @param {string} dateStr - YYYY-MM-DD
+ * @param {number} count
+ * @returns {string[]}
+ */
+export function getPreviousDates(dateStr, count) {
+  const dates = [];
+  const date = parseDateKey(dateStr);
+  for (let i = 1; i <= count; i += 1) {
+    const prev = new Date(date);
+    prev.setDate(prev.getDate() - i);
+    dates.push(getDateKey(prev));
+  }
+  return dates;
+}
+
+/**
+ * Generate all date keys in a Date object range (inclusive).
+ * @param {Date} startDate
+ * @param {Date} endDate
+ * @returns {string[]}
+ */
+export function getDateKeysInRange(startDate, endDate) {
+  const keys = [];
+  const cur = new Date(startDate);
+  cur.setHours(0, 0, 0, 0);
+  const end = new Date(endDate);
+  end.setHours(0, 0, 0, 0);
+  while (cur <= end) {
+    keys.push(getDateKey(cur));
+    cur.setDate(cur.getDate() + 1);
+  }
+  return keys;
+}
+
+/**
+ * Single time-range aggregator: aggregate visits across an inclusive date range.
+ * Uses local date comparison to avoid UTC off-by-one.
+ * @param {Object} visits - storage visits object keyed by dateKey
+ * @param {Date} startDate - inclusive start (local)
+ * @param {Date} endDate - inclusive end (local)
+ * @returns {Object} aggregated by domain {count, lastVisit, subpaths}
+ */
+export function aggregateVisitsInRange(visits, startDate, endDate) {
+  const aggregated = {};
+  const start = getStartOfDay(startDate);
+  const endDay = getStartOfDay(endDate);
+  Object.entries(visits).forEach(([dateKey, dateVisits]) => {
+    const visitDate = parseDateKey(dateKey);
+    if (visitDate >= start && visitDate <= endDay) {
+      Object.entries(dateVisits).forEach(([domain, domainData]) => {
+        if (!aggregated[domain]) {
+          aggregated[domain] = { count: 0, lastVisit: domainData.lastVisit, subpaths: {} };
+        }
+        aggregated[domain].count += domainData.count || 0;
+        if (domainData.lastVisit > aggregated[domain].lastVisit) {
+          aggregated[domain].lastVisit = domainData.lastVisit;
+        }
+        Object.entries(domainData.subpaths || {}).forEach(([sp, spData]) => {
+          if (!aggregated[domain].subpaths[sp]) {
+            aggregated[domain].subpaths[sp] = { count: 0, lastVisit: spData.lastVisit };
+          }
+          aggregated[domain].subpaths[sp].count += spData.count || 0;
+          if (spData.lastVisit > aggregated[domain].subpaths[sp].lastVisit) {
+            aggregated[domain].subpaths[sp].lastVisit = spData.lastVisit;
+          }
+        });
+      });
+    }
+  });
+  return aggregated;
+}
+
+/**
+ * Retention cutoff key (local).
+ * @param {number} retentionDays
+ * @returns {string}
+ */
+export function getRetentionCutoffKey(retentionDays = 30) {
+  const d = new Date();
+  d.setDate(d.getDate() - retentionDays);
+  return getDateKey(d);
+}
+
+export const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
+export const ONE_HOUR_MS = 60 * 60 * 1000;
+export const ONE_DAY_MS = 24 * 60 * 60 * 1000;

--- a/src/common/limit-validation.js
+++ b/src/common/limit-validation.js
@@ -1,0 +1,110 @@
+/**
+ * Shared limit-form validation controller for FocusBear.
+ * Single source of truth for all three limit forms.
+ */
+
+export const LIMIT_MIN = 1;
+export const LIMIT_MAX = 1000;
+export const LIMIT_DOMAIN_REGEX = /^[a-z0-9.-]+$/;
+
+/**
+ * Validate a single limit value (positive integer within [LIMIT_MIN, LIMIT_MAX]).
+ * @param {string|number} rawValue
+ * @returns {{valid: boolean, value?: number, error?: string}}
+ */
+export function validateLimitValue(rawValue) {
+  if (rawValue === '' || rawValue === null || rawValue === undefined) {
+    return { valid: false, error: 'Limit must be a positive integer.' };
+  }
+  const num = Number(rawValue);
+  if (!Number.isInteger(num) || num < LIMIT_MIN) {
+    return { valid: false, error: 'Enter a positive whole number (\u2265 1).' };
+  }
+  if (num > LIMIT_MAX) {
+    return { valid: false, error: `Limit must be \u2264 ${LIMIT_MAX}.` };
+  }
+  return { valid: true, value: num };
+}
+
+/**
+ * Validate a domain string (normalized).
+ * @param {string} rawDomain
+ * @returns {{valid: boolean, normalized?: string, error?: string}}
+ */
+export function validateDomain(rawDomain) {
+  const normalized = rawDomain
+    .trim()
+    .replace(/^https?:\/\//i, '')
+    .split('/')[0]
+    .toLowerCase();
+  if (!normalized || !LIMIT_DOMAIN_REGEX.test(normalized) || !normalized.includes('.')) {
+    return { valid: false, error: 'Enter a valid domain like example.com' };
+  }
+  return { valid: true, normalized };
+}
+
+/**
+ * Validate a full limit config (shared by all three forms).
+ * @param {Object} config
+ * @param {boolean} config.fiveHourEnabled
+ * @param {string|number} config.fiveHourLimit
+ * @param {boolean} config.dailyEnabled
+ * @param {string|number} config.dailyLimit
+ * @returns {{valid: boolean, error?: string}}
+ */
+// eslint-disable-next-line object-curly-newline
+export function validateLimitConfig({ fiveHourEnabled, fiveHourLimit, dailyEnabled, dailyLimit }) {
+  if (fiveHourEnabled) {
+    const r = validateLimitValue(fiveHourLimit);
+    if (!r.valid) return { valid: false, error: r.error || 'Enter a positive 5-hour limit.' };
+  }
+  if (dailyEnabled) {
+    const r = validateLimitValue(dailyLimit);
+    if (!r.valid) return { valid: false, error: r.error || 'Enter a positive daily limit.' };
+  }
+  return { valid: true };
+}
+
+/**
+ * Unified handler for limit form submissions — validates and builds normalized config.
+ * @param {Object} params
+ * @param {string} params.domain - already normalized or raw (will normalize)
+ * @param {boolean} params.enabled
+ * @param {boolean} params.fiveHourEnabled
+ * @param {string|number} params.fiveHourLimit
+ * @param {boolean} params.dailyEnabled
+ * @param {string|number} params.dailyLimit
+ * @returns {{valid: boolean, error?: string, domain?: string, config?: Object}}
+ */
+export function buildValidatedLimitConfig({
+  domain,
+  enabled,
+  fiveHourEnabled,
+  fiveHourLimit,
+  dailyEnabled,
+  dailyLimit,
+}) {
+  const domainRes = validateDomain(domain);
+  if (!domainRes.valid) return { valid: false, error: domainRes.error };
+
+  const cfgRes = validateLimitConfig({
+    fiveHourEnabled,
+    fiveHourLimit,
+    dailyEnabled,
+    dailyLimit,
+  });
+  if (!cfgRes.valid) return { valid: false, error: cfgRes.error };
+
+  const fiveHourNorm = fiveHourEnabled ? validateLimitValue(fiveHourLimit).value : 10;
+  const dailyNorm = dailyEnabled ? validateLimitValue(dailyLimit).value : 20;
+
+  return {
+    valid: true,
+    domain: domainRes.normalized,
+    config: {
+      enabled,
+      fiveHour: { enabled: fiveHourEnabled, limit: fiveHourNorm },
+      daily: { enabled: dailyEnabled, limit: dailyNorm },
+    },
+  };
+}

--- a/src/common/visualization-page.js
+++ b/src/common/visualization-page.js
@@ -14,6 +14,8 @@ import {
   createDefaultLimitConfig,
 } from '../background/storage.js';
 import { updateBlockingRules } from '../background/limits.js';
+import { getTodayKey, aggregateVisitsInRange } from './date-utils.js';
+import { validateLimitConfig, validateDomain } from './limit-validation.js';
 
 /**
  * Load aggregated stats for a given time range
@@ -51,45 +53,7 @@ export async function loadAggregatedStats(range = 'today') {
 
   const data = await chrome.storage.local.get(['visits']);
   const visits = data.visits || {};
-  const aggregated = {};
-
-  Object.entries(visits).forEach(([dateKey, dateVisits]) => {
-    // Parse date string as local date to avoid timezone issues
-    // dateKey format: "YYYY-MM-DD"
-    const [year, month, day] = dateKey.split('-').map(Number);
-    const visitDate = new Date(year, month - 1, day); // month is 0-indexed
-
-    if (visitDate >= startDate && visitDate <= now) {
-      Object.entries(dateVisits).forEach(([domain, domainData]) => {
-        if (!aggregated[domain]) {
-          aggregated[domain] = {
-            count: 0,
-            lastVisit: domainData.lastVisit,
-            subpaths: {},
-          };
-        }
-        aggregated[domain].count += domainData.count;
-        if (domainData.lastVisit > aggregated[domain].lastVisit) {
-          aggregated[domain].lastVisit = domainData.lastVisit;
-        }
-
-        Object.entries(domainData.subpaths || {}).forEach(([subpath, subpathData]) => {
-          if (!aggregated[domain].subpaths[subpath]) {
-            aggregated[domain].subpaths[subpath] = {
-              count: 0,
-              lastVisit: subpathData.lastVisit,
-            };
-          }
-          aggregated[domain].subpaths[subpath].count += subpathData.count;
-          if (subpathData.lastVisit > aggregated[domain].subpaths[subpath].lastVisit) {
-            aggregated[domain].subpaths[subpath].lastVisit = subpathData.lastVisit;
-          }
-        });
-      });
-    }
-  });
-
-  return aggregated;
+  return aggregateVisitsInRange(visits, startDate, now);
 }
 
 function getTitleForRange(range) {
@@ -150,26 +114,7 @@ async function loadPreviousPeriodData(range) {
 
   const data = await chrome.storage.local.get(['visits']);
   const visits = data.visits || {};
-  const aggregated = {};
-
-  Object.entries(visits).forEach(([dateKey, dateVisits]) => {
-    const [year, month, day] = dateKey.split('-').map(Number);
-    const visitDate = new Date(year, month - 1, day);
-
-    if (visitDate >= startDate && visitDate <= endDate) {
-      Object.entries(dateVisits).forEach(([domain, domainData]) => {
-        if (!aggregated[domain]) {
-          aggregated[domain] = { count: 0, lastVisit: domainData.lastVisit, subpaths: {} };
-        }
-        aggregated[domain].count += domainData.count;
-        if (domainData.lastVisit > aggregated[domain].lastVisit) {
-          aggregated[domain].lastVisit = domainData.lastVisit;
-        }
-      });
-    }
-  });
-
-  return aggregated;
+  return aggregateVisitsInRange(visits, startDate, endDate);
 }
 
 /**
@@ -998,37 +943,28 @@ export async function setupVisualizationPage(options = {}) {
 
     limitForm.addEventListener('submit', async (event) => {
       event.preventDefault();
-      const domainInput = limitForm.elements.domain;
-      const rawDomain = domainInput.value.trim();
-      const normalizedDomain = rawDomain
-        .replace(/^https?:\/\//i, '')
-        .split('/')[0]
-        .toLowerCase();
-
-      if (!normalizedDomain || !/^[a-z0-9.-]+$/.test(normalizedDomain)) {
-        if (limitErrorEl) {
-          limitErrorEl.textContent = 'Enter a valid domain like example.com';
-        }
-        return;
-      }
-
+      const rawDomain = limitForm.elements.domain.value;
       const enabled = limitForm.elements.enabled.checked;
       const fiveHourEnabled = limitForm.elements.fiveHourEnabled.checked;
-      const fiveHourLimit = Number(limitForm.elements.fiveHourLimit.value);
+      const fiveHourLimit = limitForm.elements.fiveHourLimit.value;
       const dailyEnabled = limitForm.elements.dailyEnabled.checked;
-      const dailyLimit = Number(limitForm.elements.dailyLimit.value);
+      const dailyLimit = limitForm.elements.dailyLimit.value;
 
-      if (fiveHourEnabled && (!Number.isInteger(fiveHourLimit) || fiveHourLimit <= 0)) {
-        if (limitErrorEl) {
-          limitErrorEl.textContent = 'Enter a positive 5-hour limit.';
-        }
+      const domainRes = validateDomain(rawDomain);
+      if (!domainRes.valid) {
+        if (limitErrorEl) limitErrorEl.textContent = domainRes.error;
         return;
       }
+      const normalizedDomain = domainRes.normalized;
 
-      if (dailyEnabled && (!Number.isInteger(dailyLimit) || dailyLimit <= 0)) {
-        if (limitErrorEl) {
-          limitErrorEl.textContent = 'Enter a positive daily limit.';
-        }
+      const limitRes = validateLimitConfig({
+        fiveHourEnabled,
+        fiveHourLimit,
+        dailyEnabled,
+        dailyLimit,
+      });
+      if (!limitRes.valid) {
+        if (limitErrorEl) limitErrorEl.textContent = limitRes.error;
         return;
       }
 
@@ -1041,11 +977,11 @@ export async function setupVisualizationPage(options = {}) {
           enabled,
           fiveHour: {
             enabled: fiveHourEnabled,
-            limit: fiveHourLimit,
+            limit: fiveHourEnabled ? Number(fiveHourLimit) : 10,
           },
           daily: {
             enabled: dailyEnabled,
-            limit: dailyLimit,
+            limit: dailyEnabled ? Number(dailyLimit) : 20,
           },
         };
 
@@ -1118,7 +1054,7 @@ export async function setupVisualizationPage(options = {}) {
         const jsonString = JSON.stringify(data, null, 2);
         const blob = new Blob([jsonString], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
-        const timestamp = new Date().toISOString().split('T')[0];
+        const timestamp = getTodayKey();
         const filename = `focusbear-data-${timestamp}.json`;
 
         const a = document.createElement('a');
@@ -1164,7 +1100,7 @@ export async function setupVisualizationPage(options = {}) {
 
         const blob = new Blob([csv], { type: 'text/csv' });
         const url = URL.createObjectURL(blob);
-        const timestamp = new Date().toISOString().split('T')[0];
+        const timestamp = getTodayKey();
         const filename = `focusbear-data-${timestamp}.csv`;
 
         const a = document.createElement('a');

--- a/src/dashboard/blocking.js
+++ b/src/dashboard/blocking.js
@@ -1,5 +1,6 @@
 import { getLimits, setLimitForDomain, normalizeLimitConfig } from '../background/storage.js';
 import { updateBlockingRules } from '../background/limits.js';
+import { validateDomain, validateLimitConfig } from '../common/limit-validation.js';
 
 document.addEventListener('DOMContentLoaded', async () => {
   await renderRulesList();
@@ -93,29 +94,41 @@ function setupForm() {
     errorEl.textContent = '';
 
     const formData = new FormData(form);
-    const domain = formData.get('domain').trim().toLowerCase();
+    const rawDomain = formData.get('domain') || '';
 
-    if (!domain) {
-      errorEl.textContent = 'Please enter a valid domain';
+    const domainRes = validateDomain(rawDomain);
+    if (!domainRes.valid) {
+      errorEl.textContent = domainRes.error;
       return;
     }
+    const domain = domainRes.normalized;
 
     try {
-      // Validate domain format (simple check)
-      if (!domain.includes('.') || domain.includes(' ')) {
-        errorEl.textContent = 'Please enter a valid domain (e.g., example.com)';
+      const fiveHourEnabled = formData.get('fiveHourEnabled') === 'on';
+      const dailyEnabled = formData.get('dailyEnabled') === 'on';
+      const fiveHourLimit = formData.get('fiveHourLimit');
+      const dailyLimit = formData.get('dailyLimit');
+
+      const limitRes = validateLimitConfig({
+        fiveHourEnabled,
+        fiveHourLimit,
+        dailyEnabled,
+        dailyLimit,
+      });
+      if (!limitRes.valid) {
+        errorEl.textContent = limitRes.error;
         return;
       }
 
       const config = {
         enabled: formData.get('enabled') === 'on',
         fiveHour: {
-          enabled: formData.get('fiveHourEnabled') === 'on',
-          limit: parseInt(formData.get('fiveHourLimit'), 10) || 10,
+          enabled: fiveHourEnabled,
+          limit: fiveHourEnabled ? Number(fiveHourLimit) : 10,
         },
         daily: {
-          enabled: formData.get('dailyEnabled') === 'on',
-          limit: parseInt(formData.get('dailyLimit'), 10) || 20,
+          enabled: dailyEnabled,
+          limit: dailyEnabled ? Number(dailyLimit) : 20,
         },
       };
 

--- a/src/dashboard/dashboard.js
+++ b/src/dashboard/dashboard.js
@@ -11,6 +11,7 @@ import {
 } from '../background/storage.js';
 import { getTodayFocusScore } from '../background/focus-score.js';
 import { categorizeDomain } from '../common/categories.js';
+import { getTodayKey, FIVE_HOUR_MS } from '../common/date-utils.js';
 
 let currentTableData = [];
 let currentLimits = {};
@@ -31,7 +32,6 @@ function getStatusColor(percent) {
   if (percent > 80) return 'var(--color-warning)';
   return 'var(--color-success)';
 }
-const FIVE_HOUR_MS = 5 * 60 * 60 * 1000;
 const tableFilters = {
   query: '',
   sortField: 'count',
@@ -85,7 +85,7 @@ async function showInsightsPopup() {
   if (!popup || !overlay || !closeBtn) return;
 
   // Check if insights were dismissed today
-  const today = new Date().toISOString().split('T')[0];
+  const today = getTodayKey();
   const { insightsDismissedDate } = await chrome.storage.local.get('insightsDismissedDate');
 
   if (insightsDismissedDate === today) {
@@ -710,8 +710,10 @@ function sortTableData(data, field, order = 'desc') {
       }
     }
 
-    let aVal = a[field];
-    let bVal = b[field];
+    // Map displayed column to its source field: visits column displays todayCount
+    const displayField = field === 'count' ? 'todayCount' : field;
+    let aVal = a[displayField];
+    let bVal = b[displayField];
 
     // Handle string comparisons
     if (field === 'domain') {

--- a/src/dashboard/domain.js
+++ b/src/dashboard/domain.js
@@ -7,6 +7,7 @@ import {
   getTodayKey,
   deleteDomainData,
 } from '../background/storage.js';
+import { validateLimitConfig } from '../common/limit-validation.js';
 
 let currentDomain = '';
 let currentLimitConfig = null;
@@ -121,17 +122,18 @@ function setupLimitFormListeners() {
 
     const enabled = form.elements.enabled.checked;
     const fiveHourEnabled = form.elements.fiveHourEnabled.checked;
-    const fiveHourLimit = Number(form.elements.fiveHourLimit.value);
+    const fiveHourLimit = form.elements.fiveHourLimit.value;
     const dailyEnabled = form.elements.dailyEnabled.checked;
-    const dailyLimit = Number(form.elements.dailyLimit.value);
+    const dailyLimit = form.elements.dailyLimit.value;
 
-    if (fiveHourEnabled && (!Number.isInteger(fiveHourLimit) || fiveHourLimit <= 0)) {
-      if (errorEl) errorEl.textContent = 'Enter a positive 5-hour limit.';
-      return;
-    }
-
-    if (dailyEnabled && (!Number.isInteger(dailyLimit) || dailyLimit <= 0)) {
-      if (errorEl) errorEl.textContent = 'Enter a positive daily limit.';
+    const limitRes = validateLimitConfig({
+      fiveHourEnabled,
+      fiveHourLimit,
+      dailyEnabled,
+      dailyLimit,
+    });
+    if (!limitRes.valid) {
+      if (errorEl) errorEl.textContent = limitRes.error;
       return;
     }
 
@@ -142,11 +144,11 @@ function setupLimitFormListeners() {
         enabled,
         fiveHour: {
           enabled: fiveHourEnabled,
-          limit: fiveHourLimit,
+          limit: fiveHourEnabled ? Number(fiveHourLimit) : 10,
         },
         daily: {
           enabled: dailyEnabled,
-          limit: dailyLimit,
+          limit: dailyEnabled ? Number(dailyLimit) : 20,
         },
       };
 


### PR DESCRIPTION
Closes #44

- One date-key utility (src/common/date-utils.js) used by storage, focus-score, achievements, notifications, blocked. Zero inline `toISOString().split('T')[0]` remains (grep-clean). Local-tz aware ``getDateKey`` fixes UTC/local mismatch.
- Single time-range aggregator `aggregateVisitsInRange` used by storage and visualization-page.
- Blocked-page countdown uses `getNextMidnight` exact reset time from same utility as storage daily reset.
- Shared limit-form controller (src/common/limit-validation.js) with LIMIT_MIN=1, LIMIT_MAX=1000; all three forms (visualization-page, domain, blocking) reject 0/negatives identically.
- Dashboard table sorts on displayed value (todayCount) for visits column.
- Lint clean, suite green (135 tests), build deterministic.