### PR TITLE
fix(xss): replace HTML-string templating with safe DOM APIs (3.6)

### DIFF
--- a/src/common/visualization-page.js
+++ b/src/common/visualization-page.js
@@ -193,9 +193,7 @@ function generateInsightsSummary(aggregatedData, limits, range, previousData = n
 
   // Top distractions
   if (top3.length > 0) {
-    const topList = top3
-      .map((d) => `<strong class="summary-highlight">${d.domain}</strong> (${d.count} visits)`)
-      .join(', ');
+    const topList = top3.map((d) => `${d.domain} (${d.count} visits)`).join(', ');
     const distractionsLabel = top3.length === 1 ? 'distraction' : 'distractions';
     parts.push(`Your top ${distractionsLabel} ${rangeText}: ${topList}`);
   }
@@ -203,16 +201,12 @@ function generateInsightsSummary(aggregatedData, limits, range, previousData = n
   // Limit status
   if (overLimitCount > 0) {
     const domainLabel = overLimitCount === 1 ? 'domain' : 'domains';
-    parts.push(
-      `<span class="summary-warning">⚠️ You exceeded limits on ${overLimitCount} ${domainLabel}</span>`,
-    );
+    parts.push(`⚠️ You exceeded limits on ${overLimitCount} ${domainLabel}`);
   } else if (nearLimitCount > 0) {
     const domainLabel = nearLimitCount === 1 ? 'domain' : 'domains';
-    parts.push(
-      `<span class="summary-warning">You're approaching limits on ${nearLimitCount} ${domainLabel}</span>`,
-    );
+    parts.push(`You're approaching limits on ${nearLimitCount} ${domainLabel}`);
   } else if (Object.keys(limits).length > 0) {
-    parts.push('<span class="summary-success">✓ All limits under control</span>');
+    parts.push('✓ All limits under control');
   }
 
   // Total domains
@@ -237,22 +231,20 @@ function generateInsightsSummary(aggregatedData, limits, range, previousData = n
         `📈 ${visitChange} more visits (${prefix}${changePercent}%)`,
         'than previous period',
       ].join(' ');
-      parts.push(`<span class="summary-warning">${warningText}</span>`);
+      parts.push(warningText);
     } else if (visitChange < 0) {
       const successText = [
         `📉 ${Math.abs(visitChange)} fewer visits (${changePercent}%)`,
         'than previous period',
       ].join(' ');
-      parts.push(`<span class="summary-success">${successText}</span>`);
+      parts.push(successText);
     } else {
       parts.push('No change from previous period');
     }
   }
 
   const totalDomainLabel = totalDomains === 1 ? 'domain' : 'domains';
-  parts.push(
-    `Tracked <strong>${totalDomains}</strong> ${totalDomainLabel} with <strong>${totalVisits}</strong> total visits`,
-  );
+  parts.push(`Tracked ${totalDomains} ${totalDomainLabel} with ${totalVisits} total visits`);
 
   return `${parts.join('. ')}.`;
 }
@@ -276,10 +268,7 @@ export function generateWeeklyInsights(weekData, limits) {
 
   // Insight 1: Most visited domain
   const topDomain = sorted[0];
-  const mostVisitedText = [
-    `You visited <span class="insight-stat">${topDomain.domain}</span> the most this week`,
-    `with <span class="insight-stat">${topDomain.count} visits</span>.`,
-  ].join(' ');
+  const mostVisitedText = `You visited ${topDomain.domain} the most this week with ${topDomain.count} visits.`;
   insights.push({
     type: 'info',
     title: '🎯 Most Visited',
@@ -295,16 +284,15 @@ export function generateWeeklyInsights(weekData, limits) {
   });
 
   if (overLimitDomains.length > 0) {
+    const domainWord = overLimitDomains.length === 1 ? 'domain' : 'domains';
     const limitTextParts = [
-      `You exceeded daily limits on <span class="insight-stat">${overLimitDomains.length} ${
-        overLimitDomains.length === 1 ? 'domain' : 'domains'
-      }</span> this week.`,
+      `You exceeded daily limits on ${overLimitDomains.length} ${domainWord} this week.`,
       'Consider adjusting your limits or reducing usage.',
-    ];
+    ].join(' ');
     insights.push({
       type: 'warning',
       title: '⚠️ Limits Exceeded',
-      text: limitTextParts.join(' '),
+      text: limitTextParts,
     });
   } else if (Object.keys(limits).length > 0) {
     insights.push({
@@ -317,10 +305,7 @@ export function generateWeeklyInsights(weekData, limits) {
   // Insight 3: Total focus switches
   const totalVisits = sorted.reduce((sum, d) => sum + d.count, 0);
   const avgPerDay = Math.round(totalVisits / 7);
-  const activityText = [
-    `You switched focus <span class="insight-stat">${totalVisits} times</span> this week,`,
-    `averaging <span class="insight-stat">${avgPerDay} switches/day</span>.`,
-  ].join(' ');
+  const activityText = `You switched focus ${totalVisits} times this week, averaging ${avgPerDay} switches/day.`;
   insights.push({
     type: 'info',
     title: '📊 Activity Summary',
@@ -334,8 +319,8 @@ export function generateWeeklyInsights(weekData, limits) {
 
     if (percentageOfTotal > 60) {
       const recommendationText = [
-        `Your top 3 sites account for <span class="insight-stat">${percentageOfTotal}%</span>`,
-        'of your focus switches. Consider setting limits to improve focus distribution.',
+        `Your top 3 sites account for ${percentageOfTotal}% of your focus switches.`,
+        'Consider setting limits to improve focus distribution.',
       ].join(' ');
       insights.push({
         type: 'warning',
@@ -429,9 +414,14 @@ export async function setupVisualizationPage(options = {}) {
       const info = document.createElement('div');
       info.className = 'limit-item-info';
 
-      let limitText = '';
+      const domainStrong = document.createElement('strong');
+      domainStrong.textContent = domain;
+      info.appendChild(domainStrong);
+      info.appendChild(document.createElement('br'));
+      const limitSpan = document.createElement('span');
       if (!normalized.enabled) {
-        limitText = '<span style="color: #999;">Disabled</span>';
+        limitSpan.textContent = 'Disabled';
+        limitSpan.style.color = '#999';
       } else {
         const parts = [];
         if (normalized.fiveHour.enabled) {
@@ -441,13 +431,13 @@ export async function setupVisualizationPage(options = {}) {
           parts.push(`${normalized.daily.limit} per day`);
         }
         if (parts.length === 0) {
-          limitText = '<span style="color: #999;">No limits active</span>';
+          limitSpan.textContent = 'No limits active';
+          limitSpan.style.color = '#999';
         } else {
-          limitText = parts.join(', ');
+          limitSpan.textContent = parts.join(', ');
         }
       }
-
-      info.innerHTML = `<strong>${domain}</strong><br/><span>${limitText}</span>`;
+      info.appendChild(limitSpan);
 
       // Quick toggle switch
       const toggleWrapper = document.createElement('label');
@@ -580,15 +570,24 @@ export async function setupVisualizationPage(options = {}) {
       const info = document.createElement('div');
       info.className = 'quick-limit-info';
 
-      let statusText = '';
+      const domainDiv = document.createElement('div');
+      domainDiv.className = 'quick-limit-domain';
+      domainDiv.textContent = domain;
+
+      const statsDiv = document.createElement('div');
+      statsDiv.className = 'quick-limit-stats';
+      const visitSpan = document.createElement('span');
+      visitSpan.className = 'visit-count';
+      visitSpan.textContent = `${visitCount} visits`;
+      statsDiv.appendChild(visitSpan);
+
+      const statusSpan = document.createElement('span');
       if (!hasLimit) {
-        statusText = `
-          <span class="limit-status no-limit">
-            Default ${defaultConfig.fiveHour.limit}/5h · ${defaultConfig.daily.limit}/day
-          </span>
-        `.trim();
+        statusSpan.className = 'limit-status no-limit';
+        statusSpan.textContent = `Default ${defaultConfig.fiveHour.limit}/5h \u00B7 ${defaultConfig.daily.limit}/day`;
       } else if (!isEnabled) {
-        statusText = '<span class="limit-status disabled">Disabled</span>';
+        statusSpan.className = 'limit-status disabled';
+        statusSpan.textContent = 'Disabled';
       } else {
         const parts = [];
         if (limitConfig.fiveHour.enabled) {
@@ -597,16 +596,13 @@ export async function setupVisualizationPage(options = {}) {
         if (limitConfig.daily.enabled) {
           parts.push(`${limitConfig.daily.limit}/day`);
         }
-        statusText = `<span class="limit-status active">${parts.join(', ')}</span>`;
+        statusSpan.className = 'limit-status active';
+        statusSpan.textContent = parts.join(', ');
       }
+      statsDiv.appendChild(document.createTextNode(' '));
+      statsDiv.appendChild(statusSpan);
 
-      info.innerHTML = `
-        <div class="quick-limit-domain">${domain}</div>
-        <div class="quick-limit-stats">
-          <span class="visit-count">${visitCount} visits</span>
-          ${statusText}
-        </div>
-      `;
+      info.append(domainDiv, statsDiv);
 
       const actions = document.createElement('div');
       actions.className = 'quick-limit-actions';
@@ -717,7 +713,7 @@ export async function setupVisualizationPage(options = {}) {
             previousData,
           );
           summaryElement.classList.add('updating');
-          summaryElement.innerHTML = summaryText;
+          summaryElement.textContent = summaryText;
           // Remove animation class after animation completes
           setTimeout(() => {
             summaryElement.classList.remove('updating');
@@ -736,13 +732,17 @@ export async function setupVisualizationPage(options = {}) {
       console.error('Error rendering visualization:', error);
       console.error('Error stack:', error.stack);
       if (graphContainer) {
-        const errorHtml = `
-          <div class="graph-error">
-            Error loading visualization<br/>
-            <small style="font-size: 11px; opacity: 0.7;">${error.message}</small>
-          </div>
-        `;
-        graphContainer.innerHTML = errorHtml;
+        graphContainer.replaceChildren();
+        const errorDiv = document.createElement('div');
+        errorDiv.className = 'graph-error';
+        errorDiv.appendChild(document.createTextNode('Error loading visualization'));
+        errorDiv.appendChild(document.createElement('br'));
+        const small = document.createElement('small');
+        small.style.fontSize = '11px';
+        small.style.opacity = '0.7';
+        small.textContent = error.message;
+        errorDiv.appendChild(small);
+        graphContainer.appendChild(errorDiv);
       }
     }
   };

--- a/src/content/countdown-toast.js
+++ b/src/content/countdown-toast.js
@@ -54,16 +54,16 @@ if (!window.focusBearToastInjected) {
 
     toast.classList.add(`focusbear-toast-${severity}`);
 
-    // Build message
-    let message;
+    // Build message text
     const limitLabel = limitType === 'fiveHour' ? '5-hour window' : 'day';
     const timeframeLabel = limitType === 'fiveHour' ? 'window' : 'day';
+    let messageText;
     if (remaining === 0) {
-      message = `<strong>${domain}</strong><br/>Limit reached for this ${limitLabel}`;
+      messageText = `Limit reached for this ${limitLabel}`;
     } else if (remaining === 1) {
-      message = `<strong>${domain}</strong><br/>1 visit left this ${timeframeLabel}`;
+      messageText = `1 visit left this ${timeframeLabel}`;
     } else {
-      message = `<strong>${domain}</strong><br/>${remaining} visits left this ${limitLabel}`;
+      messageText = `${remaining} visits left this ${limitLabel}`;
     }
 
     // Icon based on severity
@@ -74,10 +74,19 @@ if (!window.focusBearToastInjected) {
       icon = '⚠️';
     }
 
-    toast.innerHTML = `
-      <div class="focusbear-toast-icon">${icon}</div>
-      <div class="focusbear-toast-content">${message}</div>
-    `;
+    const iconEl = document.createElement('div');
+    iconEl.className = 'focusbear-toast-icon';
+    iconEl.textContent = icon;
+
+    const contentEl = document.createElement('div');
+    contentEl.className = 'focusbear-toast-content';
+    const domainStrong = document.createElement('strong');
+    domainStrong.textContent = domain;
+    contentEl.appendChild(domainStrong);
+    contentEl.appendChild(document.createElement('br'));
+    contentEl.appendChild(document.createTextNode(messageText));
+
+    toast.append(iconEl, contentEl);
 
     // Add to container
     toastContainer.appendChild(toast);

--- a/src/dashboard/blocking.js
+++ b/src/dashboard/blocking.js
@@ -27,59 +27,83 @@ async function renderRulesList() {
     const item = document.createElement('div');
     item.className = 'rule-item';
 
-    // Determine status text
-    const badges = [];
+    const ruleInfo = document.createElement('div');
+    ruleInfo.className = 'rule-info';
+
+    const ruleIcon = document.createElement('div');
+    ruleIcon.className = 'rule-icon';
+    const favicon = document.createElement('img');
+    favicon.src = `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=32`;
+    favicon.alt = '';
+    favicon.style.width = '20px';
+    favicon.style.height = '20px';
+    favicon.style.opacity = '0.8';
+    favicon.onerror = function () {
+      this.style.display = 'none';
+    };
+    ruleIcon.appendChild(favicon);
+
+    const ruleDetails = document.createElement('div');
+    ruleDetails.className = 'rule-details';
+    const domainHeading = document.createElement('h3');
+    domainHeading.textContent = domain;
+    const badgesContainer = document.createElement('div');
+    badgesContainer.className = 'rule-badges';
+
+    const createBadge = (label, cssText) => {
+      const badge = document.createElement('span');
+      badge.className = 'rule-badge';
+      badge.textContent = label;
+      if (cssText) badge.style.cssText = cssText;
+      return badge;
+    };
+
     const mutedStyle = 'border-color: var(--color-text-muted); color: var(--color-text-muted);';
     const successStyle = 'border-color: var(--color-success); color: var(--color-success);';
     if (!normalized.enabled) {
-      badges.push(`<span class="rule-badge" style="${mutedStyle}">Disabled</span>`);
+      badgesContainer.appendChild(createBadge('Disabled', mutedStyle));
     } else {
-      badges.push(`<span class="rule-badge" style="${successStyle}">Active</span>`);
+      badgesContainer.appendChild(createBadge('Active', successStyle));
       if (normalized.fiveHour.enabled) {
-        badges.push(`<span class="rule-badge">${normalized.fiveHour.limit} / 5h</span>`);
+        badgesContainer.appendChild(createBadge(`${normalized.fiveHour.limit} / 5h`, ''));
       }
       if (normalized.daily.enabled) {
-        badges.push(`<span class="rule-badge">${normalized.daily.limit} / day</span>`);
+        badgesContainer.appendChild(createBadge(`${normalized.daily.limit} / day`, ''));
       }
     }
 
-    const faviconUrl = `https://www.google.com/s2/favicons?domain=${domain}&sz=32`;
+    ruleDetails.append(domainHeading, badgesContainer);
+    ruleInfo.append(ruleIcon, ruleDetails);
+
+    const ruleActions = document.createElement('div');
+    ruleActions.className = 'rule-actions';
+
     const toggleTitle = normalized.enabled ? 'Disable' : 'Enable';
     const toggleIcon = normalized.enabled ? '⏸️' : '▶️';
 
-    item.innerHTML = `
-      <div class="rule-info">
-        <div class="rule-icon">
-          <img src="${faviconUrl}" alt=""
-            style="width: 20px; height: 20px; opacity: 0.8;"
-            onerror="this.style.display='none'">
-        </div>
-        <div class="rule-details">
-          <h3>${domain}</h3>
-          <div class="rule-badges">
-            ${badges.join('')}
-          </div>
-        </div>
-      </div>
-      <div class="rule-actions">
-        <button class="btn-icon toggle-btn" title="${toggleTitle}"
-          data-domain="${domain}">${toggleIcon}</button>
-        <button class="btn-icon edit-btn" title="Edit"
-          data-domain="${domain}">✏️</button>
-        <button class="btn-icon delete-btn" title="Delete"
-          data-domain="${domain}">🗑️</button>
-      </div>
-    `;
-
-    // Add event listeners
-    const toggleBtn = item.querySelector('.toggle-btn');
+    const toggleBtn = document.createElement('button');
+    toggleBtn.className = 'btn-icon toggle-btn';
+    toggleBtn.title = toggleTitle;
+    toggleBtn.dataset.domain = domain;
+    toggleBtn.textContent = toggleIcon;
     toggleBtn.addEventListener('click', () => toggleRule(domain, normalized));
 
-    const editBtn = item.querySelector('.edit-btn');
+    const editBtn = document.createElement('button');
+    editBtn.className = 'btn-icon edit-btn';
+    editBtn.title = 'Edit';
+    editBtn.dataset.domain = domain;
+    editBtn.textContent = '✏️';
     editBtn.addEventListener('click', () => editRule(domain, normalized));
 
-    const deleteBtn = item.querySelector('.delete-btn');
+    const deleteBtn = document.createElement('button');
+    deleteBtn.className = 'btn-icon delete-btn';
+    deleteBtn.title = 'Delete';
+    deleteBtn.dataset.domain = domain;
+    deleteBtn.textContent = '🗑️';
     deleteBtn.addEventListener('click', () => deleteRule(domain));
+
+    ruleActions.append(toggleBtn, editBtn, deleteBtn);
+    item.append(ruleInfo, ruleActions);
 
     rulesList.appendChild(item);
   });

--- a/src/dashboard/dashboard.js
+++ b/src/dashboard/dashboard.js
@@ -96,31 +96,38 @@ async function showInsightsPopup() {
   // Load and display insights content
   const insightsContent = document.getElementById('insights-content');
   if (insightsContent) {
+    const createInsightCard = (type, title, text) => {
+      const card = document.createElement('div');
+      card.className = `insight-card${type === 'info' ? '' : ` ${type}`}`;
+      const titleEl = document.createElement('div');
+      titleEl.className = 'insight-card-title';
+      titleEl.textContent = title;
+      const textEl = document.createElement('div');
+      textEl.className = 'insight-card-text';
+      textEl.textContent = text;
+      card.append(titleEl, textEl);
+      return card;
+    };
+
     try {
       const weekData = await loadAggregatedStats('week');
       const limits = await getLimits();
       const insights = generateWeeklyInsights(weekData, limits);
 
+      insightsContent.replaceChildren();
       if (insights.length === 0) {
         const msg = 'No insights available for this week yet. Start browsing to see your patterns!';
-        insightsContent.innerHTML = `<div class="insight-card"><div class="insight-card-text">${msg}</div></div>`;
+        insightsContent.appendChild(createInsightCard('info', '', msg));
       } else {
-        insightsContent.innerHTML = insights
-          .map(
-            (insight) => `
-            <div class="insight-card ${insight.type === 'info' ? '' : insight.type}">
-                <div class="insight-card-title">${insight.title}</div>
-                <div class="insight-card-text">${insight.text}</div>
-            </div>
-        `,
-          )
-          .join('');
+        insights.forEach((insight) => {
+          insightsContent.appendChild(createInsightCard(insight.type, insight.title, insight.text));
+        });
       }
     } catch (error) {
       console.error('Error generating weekly insights:', error);
       const errorMsg = 'Unable to load insights at this time.';
-      const errorHtml = `<div class="insight-card warning"><div class="insight-card-text">${errorMsg}</div></div>`;
-      insightsContent.innerHTML = errorHtml;
+      insightsContent.replaceChildren();
+      insightsContent.appendChild(createInsightCard('warning', '', errorMsg));
     }
   }
 
@@ -601,7 +608,7 @@ function renderTable() {
 
     if (!row.limit || !row.limit.enabled) {
       statusBadge.classList.add('no-limit');
-      statusBadge.innerHTML = 'No Limit';
+      statusBadge.textContent = 'No Limit';
       statusBadge.title = 'No limits configured for this domain';
     } else {
       // Evaluate five-hour and daily limits independently using today's data
@@ -617,20 +624,20 @@ function renderTable() {
 
       if (overFiveHour || overDaily) {
         statusBadge.classList.add('over-limit');
-        statusBadge.innerHTML = 'Blocked';
+        statusBadge.textContent = 'Blocked';
         statusBadge.title = 'Limit exceeded';
       } else if (nearFiveHour || nearDaily) {
         statusBadge.classList.add('near-limit');
-        statusBadge.innerHTML = 'Near Limit';
+        statusBadge.textContent = 'Near Limit';
         statusBadge.title = 'Approaching limit';
       } else if (dailyLimit || fiveHourLimit) {
         statusBadge.classList.add('under-limit');
-        statusBadge.innerHTML = 'On Track';
+        statusBadge.textContent = 'On Track';
         statusBadge.title = 'Within limits';
       } else {
         // Limit is enabled but no daily limit configured
         statusBadge.classList.add('no-limit');
-        statusBadge.innerHTML = 'Unlimited';
+        statusBadge.textContent = 'Unlimited';
         statusBadge.title = 'No active limits';
       }
     }
@@ -820,43 +827,54 @@ async function handleDomainDrilldown(event) {
 
   const subpathCount = Object.keys(domainData.subpaths || {}).length;
 
-  let limitBadges = '<span class="limit-status-badge limit-disabled">No limits</span>';
+  panelHeader.replaceChildren();
+  const drilldownHeader = document.createElement('div');
+  drilldownHeader.className = 'drilldown-table-header';
+
+  const drilldownInfo = document.createElement('div');
+  drilldownInfo.className = 'drilldown-info';
+  const drilldownTitle = document.createElement('h3');
+  drilldownTitle.textContent = `Path Statistics for ${domain}`;
+  const subtitle = document.createElement('p');
+  subtitle.className = 'panel-subtitle';
+  subtitle.textContent = `${domainData.count} total visits \u00B7 ${subpathCount} subpaths`;
+  drilldownInfo.append(drilldownTitle, subtitle);
+
+  const drilldownStatus = document.createElement('div');
+  drilldownStatus.className = 'drilldown-status';
   if (limitConfig && limitConfig.enabled) {
-    limitBadges = `<span class="limit-status-badge limit-enabled">✓ Limits Active</span>
-      <span class="limit-details">
-        ${limitConfig.fiveHour?.enabled ? `${limitConfig.fiveHour.limit}/5hr` : ''}
-        ${limitConfig.fiveHour?.enabled && limitConfig.daily?.enabled ? ' • ' : ''}
-        ${limitConfig.daily?.enabled ? `${limitConfig.daily.limit}/day` : ''}
-      </span>`;
+    const activeBadge = document.createElement('span');
+    activeBadge.className = 'limit-status-badge limit-enabled';
+    activeBadge.textContent = '\u2713 Limits Active';
+    drilldownStatus.appendChild(activeBadge);
+    const detailsSpan = document.createElement('span');
+    detailsSpan.className = 'limit-details';
+    const detailsParts = [];
+    if (limitConfig.fiveHour?.enabled) detailsParts.push(`${limitConfig.fiveHour.limit}/5hr`);
+    if (limitConfig.daily?.enabled) detailsParts.push(`${limitConfig.daily.limit}/day`);
+    detailsSpan.textContent = detailsParts.join(' \u00B7 ');
+    drilldownStatus.appendChild(detailsSpan);
+  } else {
+    const disabledBadge = document.createElement('span');
+    disabledBadge.className = 'limit-status-badge limit-disabled';
+    disabledBadge.textContent = 'No limits';
+    drilldownStatus.appendChild(disabledBadge);
   }
+  const editBtn = document.createElement('button');
+  editBtn.className = 'drilldown-edit-btn';
+  editBtn.dataset.domain = domain;
+  editBtn.textContent = 'Edit Limitation Settings';
+  editBtn.addEventListener('click', () => {
+    window.dispatchEvent(
+      new CustomEvent('openDomainSettings', {
+        detail: { domain },
+      }),
+    );
+  });
+  drilldownStatus.appendChild(editBtn);
 
-  // Create header with domain info and limitation status
-  panelHeader.innerHTML = `
-  <div class="drilldown-table-header">
-    <div class="drilldown-info">
-      <h3>Path Statistics for ${domain}</h3>
-      <p class="panel-subtitle">${domainData.count} total visits • ${subpathCount} subpaths</p>
-    </div>
-    <div class="drilldown-status">
-      ${limitBadges}
-      <button class="drilldown-edit-btn" data-domain="${domain}">
-        Edit Limitation Settings
-      </button>
-    </div>
-  </div>
-`;
-
-  // Add click handler for edit button
-  const editBtn = panelHeader.querySelector('.drilldown-edit-btn');
-  if (editBtn) {
-    editBtn.addEventListener('click', () => {
-      window.dispatchEvent(
-        new CustomEvent('openDomainSettings', {
-          detail: { domain },
-        }),
-      );
-    });
-  }
+  drilldownHeader.append(drilldownInfo, drilldownStatus);
+  panelHeader.appendChild(drilldownHeader);
 
   // Render subpath table
   renderSubpathTable(domain, domainData);
@@ -945,20 +963,39 @@ function renderSubpathTable(domain, domainData) {
     const lastVisitDate = new Date(subpath.lastVisit).toLocaleString();
 
     const row = document.createElement('tr');
-    row.innerHTML = `
-      <td class="subpath-cell">
-        <span class="subpath-domain">${domain}</span>
-        <span class="subpath-path">${subpath.subpath}</span>
-      </td>
-      <td class="visits-cell">${subpath.count}</td>
-      <td class="date-cell">${lastVisitDate}</td>
-      <td class="percentage-cell">
-        <div class="percentage-bar-container">
-          <div class="percentage-bar" style="width: ${percentage}%"></div>
-          <span class="percentage-text">${percentage}%</span>
-        </div>
-      </td>
-    `;
+
+    const subpathCell = document.createElement('td');
+    subpathCell.className = 'subpath-cell';
+    const domainSpan = document.createElement('span');
+    domainSpan.className = 'subpath-domain';
+    domainSpan.textContent = domain;
+    const pathSpan = document.createElement('span');
+    pathSpan.className = 'subpath-path';
+    pathSpan.textContent = subpath.subpath;
+    subpathCell.append(domainSpan, pathSpan);
+
+    const visitsCell = document.createElement('td');
+    visitsCell.className = 'visits-cell';
+    visitsCell.textContent = String(subpath.count);
+
+    const dateCell = document.createElement('td');
+    dateCell.className = 'date-cell';
+    dateCell.textContent = lastVisitDate;
+
+    const percentageCell = document.createElement('td');
+    percentageCell.className = 'percentage-cell';
+    const barContainer = document.createElement('div');
+    barContainer.className = 'percentage-bar-container';
+    const bar = document.createElement('div');
+    bar.className = 'percentage-bar';
+    bar.style.width = `${percentage}%`;
+    const percentText = document.createElement('span');
+    percentText.className = 'percentage-text';
+    percentText.textContent = `${percentage}%`;
+    barContainer.append(bar, percentText);
+    percentageCell.appendChild(barContainer);
+
+    row.append(subpathCell, visitsCell, dateCell, percentageCell);
 
     tbody.appendChild(row);
   });

--- a/src/dashboard/domain.js
+++ b/src/dashboard/domain.js
@@ -265,7 +265,11 @@ function updateStatsUI(stats) {
         month: 'short',
         day: 'numeric',
       });
-      item.innerHTML = `<strong>${dayLabel}</strong><span>${entry.count} visits</span>`;
+      const strong = document.createElement('strong');
+      strong.textContent = dayLabel;
+      const span = document.createElement('span');
+      span.textContent = `${entry.count} visits`;
+      item.append(strong, span);
       historyList.appendChild(item);
     });
   }

--- a/src/popup/graph.js
+++ b/src/popup/graph.js
@@ -74,7 +74,7 @@ export function renderRadialGraph(container, data, options = {}) {
   // Back Button
   const backBtn = document.createElement('button');
   backBtn.className = 'graph-back-btn';
-  backBtn.innerHTML = '← Back to Universe';
+  backBtn.textContent = '← Back to Universe';
   backBtn.style.position = 'absolute';
   backBtn.style.top = '10px';
   backBtn.style.left = '10px';
@@ -308,25 +308,34 @@ export function renderRadialGraph(container, data, options = {}) {
         // eslint-disable-next-line newline-per-chained-call
         d3.select(this).select('circle').transition().duration(200).attr('transform', 'scale(1.1)');
 
-        let content = '';
+        tooltip.selectAll('*').remove();
         if (d.group === 'center') {
-          content = '<strong>You</strong><br/>Center of your digital universe';
+          tooltip.append('strong').text('You');
+          tooltip.append('br');
+          tooltip.append('span').text('Center of your digital universe');
         } else if (d.group === 'domain' || d.group === 'center-domain') {
-          const badgeInfo = badges[d.id] ? `<br/>🏆 Focus Hero (${badges[d.id].streak} days!)` : '';
-          content = `
-            <strong>${d.id}</strong><br/>
-            <span style="opacity:0.8">${d.categoryName || 'Website'}</span><br/>
-            <strong>${d.count}</strong> visits${badgeInfo}
-          `;
+          tooltip.append('strong').text(d.id);
+          tooltip.append('br');
+          tooltip
+            .append('span')
+            .style('opacity', '0.8')
+            .text(d.categoryName || 'Website');
+          tooltip.append('br');
+          tooltip.append('strong').text(String(d.count));
+          tooltip.append('span').text(' visits');
+          if (badges[d.id]) {
+            tooltip.append('br');
+            tooltip.append('span').text(`\u{1F3C6} Focus Hero (${badges[d.id].streak} days!)`);
+          }
         } else if (d.group === 'subpath') {
-          content = `
-            <strong>${d.id}</strong><br/>
-            Path on ${d.domain}<br/>
-            <strong>${d.count}</strong> visits
-          `;
+          tooltip.append('strong').text(d.id);
+          tooltip.append('br');
+          tooltip.append('span').text(`Path on ${d.domain}`);
+          tooltip.append('br');
+          tooltip.append('strong').text(String(d.count));
+          tooltip.append('span').text(' visits');
         }
-
-        tooltip.html(content).style('visibility', 'visible');
+        tooltip.style('visibility', 'visible');
       })
       .on('mousemove', (event) => {
         tooltip.style('top', `${event.pageY - 40}px`).style('left', `${event.pageX + 10}px`);


### PR DESCRIPTION
Closes #47

Eliminate `innerHTML`/`tooltip.html()` with interpolated domain/subpath at all 8+ sites (countdown-toast, graph tooltip, visualization-page limits/quick-limits/summary/error, blocking rules, dashboard insights/drilldown/subpath table, domain history) by building nodes via `createElement`/`textContent`/`appendChild`/`DocumentFragment` and D3 `selectAll remove + append + text`.

Domains/subpaths containing HTML metacharacters now render as literal text.

Verification:
- `grep -rn 'innerHTML' src/` shows only safe static clears (`innerHTML = ''`) or static headers without interpolation
- `grep -rn 'tooltip.html' src/` zero
- `npm test -- --ci` 135 passed
- `npm run lint` clean
- `npm run build` stamps dist/manifest.json correctly