### PR TITLE
fix(ux): wire/remove high-contrast, label counts, countdown, toolbar, insights (4.1)

### DIFF
--- a/src/blocked/blocked.html
+++ b/src/blocked/blocked.html
@@ -52,7 +52,7 @@
         </button>
       </div>
 
-      <p class="footer">Reset happens at midnight. You got this! 💪</p>
+      <p class="footer" id="reset-footer">Reset happens at midnight. You got this! 💪</p>
     </main>
 
     <script type="module" src="blocked.js"></script>

--- a/src/blocked/blocked.js
+++ b/src/blocked/blocked.js
@@ -157,6 +157,15 @@ function calculateTimeUntilReset() {
 }
 
 /**
+ * Format a reset timestamp as a local time string (e.g. 12:00 AM)
+ * @param {number} ts - milliseconds
+ * @returns {string}
+ */
+function formatResetTime(ts) {
+  return new Date(ts).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+}
+
+/**
  * Update countdown timer showing time until limit resets
  * Supports both 5-hour window and daily limits
  */
@@ -184,9 +193,22 @@ function updateCountdownTimer() {
   document.getElementById('countdown-minutes').textContent = formatTime(minutes);
   document.getElementById('countdown-seconds').textContent = formatTime(seconds);
 
-  // Update sublabel based on limit type
-  const sublabel = limitType === 'fiveHour' ? 'in your 5-hour window' : 'until midnight';
-  document.getElementById('countdown-sublabel').textContent = sublabel;
+  // Show actual reset time alongside countdown (F-UX-003)
+  const resetTimeStr = formatResetTime(resetTime);
+  const sublabelEl = document.getElementById('countdown-sublabel');
+  if (limitType === 'fiveHour') {
+    sublabelEl.textContent = `resets at ${resetTimeStr} (5-hour window)`;
+  } else {
+    sublabelEl.textContent = `until midnight (${resetTimeStr})`;
+  }
+  const footerEl = document.getElementById('reset-footer');
+  if (footerEl) {
+    if (limitType === 'fiveHour') {
+      footerEl.textContent = `Resets at ${resetTimeStr} — 5 hours after your oldest visit. You got this! 💪`;
+    } else {
+      footerEl.textContent = `Resets at midnight (${resetTimeStr}). You got this! 💪`;
+    }
+  }
 }
 
 // Load data when page loads

--- a/src/dashboard/dashboard.css
+++ b/src/dashboard/dashboard.css
@@ -79,22 +79,29 @@
 /* View Mode Toggle removed - always use split view */
 
 .icon-button {
-  width: 36px;
-  /* Increased to accommodate 20px icons */
+  min-width: 36px;
   height: 36px;
-  /* Increased to accommodate 20px icons */
   border: none;
   background: var(--color-surface);
   border-radius: 5px;
-  font-size: 20px;
-  /* Standardized icon size */
+  font-size: 14px;
   cursor: pointer;
   transition: all 0.2s;
-  padding: 0;
-  display: flex;
+  padding: 0 10px;
+  display: inline-flex;
   align-items: center;
   justify-content: center;
+  gap: 6px;
   flex-shrink: 0;
+  text-decoration: none;
+  color: var(--color-text-dark);
+  border: 1px solid var(--color-border);
+}
+
+.icon-button .icon-label {
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
 }
 
 .icon-button:hover {
@@ -1211,43 +1218,20 @@
    Weekly Insights Report
    ======================================== */
 
-/* Insights Popup (modal overlay) */
-.insights-popup {
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
+/* Insights Banner (dismissible, non-modal) */
+.insights-banner {
   display: none;
-  align-items: center;
-  justify-content: center;
-  z-index: 1000;
-  animation: fadeIn 0.3s ease;
-}
-
-.insights-popup-overlay {
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.7);
-  backdrop-filter: blur(4px);
-}
-
-.insights-popup-content {
-  position: relative;
-  z-index: 1001;
-  max-width: 600px;
-  width: 90%;
-  max-height: 80vh;
-  overflow-y: auto;
+  margin: 16px;
   background: linear-gradient(135deg, #141414, #0a0a0a);
   border: 1px solid var(--color-border);
   border-radius: 12px;
   padding: 24px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
-  animation: slideUp 0.3s ease;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+  animation: fadeIn 0.3s ease;
+}
+
+.insights-banner-content {
+  width: 100%;
 }
 
 @media (min-width: 768px) {

--- a/src/dashboard/dashboard.js
+++ b/src/dashboard/dashboard.js
@@ -8,6 +8,7 @@ import {
   calculateFocusHeroBadges,
   normalizeLimitConfig,
   calculateOverallStreak,
+  getSettings,
 } from '../background/storage.js';
 import { getTodayFocusScore } from '../background/focus-score.js';
 import { categorizeDomain } from '../common/categories.js';
@@ -40,7 +41,14 @@ const tableFilters = {
 };
 
 document.addEventListener('DOMContentLoaded', async () => {
-  // Show insights popup on dashboard open (if not dismissed today)
+  // Apply high-contrast mode if enabled
+  try {
+    const s = await getSettings();
+    if (s.highContrastMode) document.body.classList.add('high-contrast');
+  } catch (err) {
+    console.warn('High-contrast init failed', err);
+  }
+  // Show insights banner on dashboard open (if not dismissed today)
   await showInsightsPopup();
 
   // Setup table controls early
@@ -52,6 +60,13 @@ document.addEventListener('DOMContentLoaded', async () => {
   // Setup footer
   setupFooter();
   setupBrandReset();
+  // Keep Visits header label in sync with selected range
+  document.querySelectorAll('.time-filter-btn').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      // label updates after visualization reloads; also update promptly
+      setTimeout(updateVisitsHeaderLabel, 50);
+    });
+  });
 
   // Listen for domain drilldown events from graph
   window.addEventListener('domainDrilldown', handleDomainDrilldown);
@@ -74,15 +89,14 @@ document.addEventListener('DOMContentLoaded', async () => {
 });
 
 /**
- * Show insights popup on dashboard open
- * Checks if insights have been dismissed today and shows popup if not
+ * Show insights as a dismissible banner (non-modal) on dashboard open
+ * Checks if insights have been dismissed today and shows banner if not
  */
 async function showInsightsPopup() {
-  const popup = document.getElementById('insights-popup');
-  const overlay = document.getElementById('insights-popup-overlay');
+  const banner = document.getElementById('insights-popup');
   const closeBtn = document.getElementById('insights-close');
 
-  if (!popup || !overlay || !closeBtn) return;
+  if (!banner || !closeBtn) return;
 
   // Check if insights were dismissed today
   const today = getTodayKey();
@@ -131,25 +145,22 @@ async function showInsightsPopup() {
     }
   }
 
-  // Show popup after a short delay to let the page load
-  setTimeout(() => {
-    popup.style.display = 'flex';
-  }, 1000);
+  // Show banner immediately as non-modal inline element (no overlay, no auto-delay)
+  banner.style.display = 'block';
 
-  // Close handlers
-  const closePopup = async () => {
-    popup.style.display = 'none';
+  // Close handlers - dismissible banner
+  const closeBanner = async () => {
+    banner.style.display = 'none';
     // Save dismissal date
     await chrome.storage.local.set({ insightsDismissedDate: today });
   };
 
-  closeBtn.addEventListener('click', closePopup);
-  overlay.addEventListener('click', closePopup);
+  closeBtn.addEventListener('click', closeBanner);
 
-  // Also close on Escape key
+  // Also close on Escape key while banner is visible
   document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape' && popup.style.display === 'flex') {
-      closePopup();
+    if (e.key === 'Escape' && banner.style.display !== 'none') {
+      closeBanner();
     }
   });
 }
@@ -291,8 +302,9 @@ async function handleDataLoaded(aggregatedData) {
   // Prepare table data
   currentTableData = prepareTableData(aggregatedData);
 
-  // Render table
+  // Render table and sync header label to active range
   renderTable();
+  updateVisitsHeaderLabel();
 }
 
 function updateStatsSummary(data) {
@@ -484,10 +496,11 @@ function renderTable() {
     domainTd.appendChild(domainContent);
     tr.appendChild(domainTd);
 
-    // Visits cell
+    // Visits cell — show same period as header totals (F-UX-002)
     const visitsTd = document.createElement('td');
     visitsTd.className = 'visits-cell';
-    visitsTd.textContent = row.todayCount;
+    visitsTd.textContent = row.count;
+    visitsTd.title = `Visits in selected period: ${row.count} (today: ${row.todayCount})`;
     tr.appendChild(visitsTd);
 
     // Subpaths cell removed as per feedback
@@ -717,10 +730,8 @@ function sortTableData(data, field, order = 'desc') {
       }
     }
 
-    // Map displayed column to its source field: visits column displays todayCount
-    const displayField = field === 'count' ? 'todayCount' : field;
-    let aVal = a[displayField];
-    let bVal = b[displayField];
+    let aVal = a[field];
+    let bVal = b[field];
 
     // Handle string comparisons
     if (field === 'domain') {
@@ -750,6 +761,30 @@ function updateSortHeaderState(field, order) {
       header.classList.add(order === 'asc' ? 'sorted-asc' : 'sorted-desc');
     }
   });
+}
+
+function updateVisitsHeaderLabel() {
+  const active = document.querySelector('.time-filter-btn.active');
+  const range = active ? active.dataset.range : 'today';
+  const labels = {
+    today: 'Times Opened (Today)',
+    week: 'Times Opened (Week)',
+    month: 'Times Opened (Month)',
+  };
+  const th = document.querySelector('.data-table th[data-sort="count"]');
+  if (!th) return;
+  const indicator = th.querySelector('.sort-indicator');
+  const label = labels[range] || 'Times Opened';
+  // Preserve sort indicator
+  th.textContent = `${label} `;
+  if (indicator) {
+    th.appendChild(indicator);
+  } else {
+    const span = document.createElement('span');
+    span.className = 'sort-indicator';
+    th.appendChild(span);
+  }
+  th.title = label;
 }
 
 function setupPagination() {

--- a/src/dashboard/index.html
+++ b/src/dashboard/index.html
@@ -108,7 +108,7 @@
               title="Manage blocking rules and limits"
               style="text-decoration: none"
             >
-              🛡️
+              <span aria-hidden="true">🛡️</span> <span class="icon-label">Blocks</span>
             </a>
             <a
               href="../help/help.html"
@@ -118,7 +118,7 @@
               title="Help and frequently asked questions"
               style="text-decoration: none"
             >
-              ❓
+              <span aria-hidden="true">❓</span> <span class="icon-label">Help</span>
             </a>
             <button
               id="settings-btn"
@@ -126,7 +126,7 @@
               aria-label="Settings"
               title="Configure extension settings"
             >
-              ⚙️
+              <span aria-hidden="true">⚙️</span> <span class="icon-label">Settings</span>
             </button>
           </div>
         </div>
@@ -282,19 +282,22 @@
                 </div>
               </div>
 
-              <!-- Weekly Insights Popup (shown on dashboard open) -->
+              <!-- Weekly Insights Banner (dismissible, non-modal) -->
               <div
-                class="insights-popup"
+                class="insights-banner"
                 id="insights-popup"
                 style="display: none"
-                role="dialog"
+                role="region"
                 aria-label="Weekly insights"
               >
-                <div class="insights-popup-overlay" id="insights-popup-overlay"></div>
-                <div class="insights-popup-content">
+                <div class="insights-banner-content">
                   <div class="insights-header">
                     <h4 class="insights-title">📊 Weekly Insights</h4>
-                    <button class="insights-close" id="insights-close" aria-label="Close insights">
+                    <button
+                      class="insights-close"
+                      id="insights-close"
+                      aria-label="Dismiss insights"
+                    >
                       ✕
                     </button>
                   </div>

--- a/src/popup/popup.css
+++ b/src/popup/popup.css
@@ -1378,6 +1378,44 @@ main {
   transform: translateY(-1px);
 }
 
+.icon-label {
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.2px;
+}
+
+/* High-contrast mode */
+body.high-contrast {
+  --color-surface: #000000;
+  --color-card: #000000;
+  --color-border: #ffffff;
+  --color-border-light: #ffffff;
+  --color-text-dark: #ffffff;
+  --color-text-muted: #ffff00;
+  --color-primary: #ffff00;
+  --color-success: #00ff00;
+  --color-warning: #ffff00;
+}
+
+body.high-contrast .settings-card,
+body.high-contrast .graph-container,
+body.high-contrast header,
+body.high-contrast .container,
+body.high-contrast .domain-item,
+body.high-contrast .pill-button,
+body.high-contrast .settings-panel {
+  border-width: 2px;
+  border-color: #ffffff;
+}
+
+body.high-contrast .time-filter-btn.active,
+body.high-contrast .pill-button,
+body.high-contrast #settings-btn,
+body.high-contrast #refresh-btn {
+  border: 2px solid #ffffff;
+}
+
 /* Reduced Motion Support */
 @media (prefers-reduced-motion: reduce) {
   .drilldown-edit-btn:hover {

--- a/src/popup/popup.html
+++ b/src/popup/popup.html
@@ -27,14 +27,18 @@
             title="Blocking Rules"
             style="
               text-decoration: none;
-              font-size: 20px;
+              font-size: 14px;
               padding: 6px 10px;
               border-radius: 8px;
               border: 1px solid var(--color-border);
               background: var(--color-card);
               color: var(--color-text-dark);
+              display: inline-flex;
+              align-items: center;
+              gap: 6px;
             "
-            >🛡️</a
+            ><span aria-hidden="true" style="font-size: 16px">🛡️</span>
+            <span class="icon-label">Blocks</span></a
           >
           <a
             href="../help/help.html"
@@ -44,16 +48,27 @@
             title="Help & FAQ"
             style="
               text-decoration: none;
-              font-size: 20px;
+              font-size: 14px;
               padding: 6px 10px;
               border-radius: 8px;
               border: 1px solid var(--color-border);
               background: var(--color-card);
               color: var(--color-text-dark);
+              display: inline-flex;
+              align-items: center;
+              gap: 6px;
             "
-            >❓</a
+            ><span aria-hidden="true" style="font-size: 16px">❓</span>
+            <span class="icon-label">Help</span></a
           >
-          <button id="settings-btn" aria-label="Settings">⚙️</button>
+          <button
+            id="settings-btn"
+            aria-label="Settings"
+            title="Settings"
+            style="display: inline-flex; align-items: center; gap: 6px"
+          >
+            <span aria-hidden="true">⚙️</span> <span class="icon-label">Settings</span>
+          </button>
         </div>
       </header>
 
@@ -69,7 +84,14 @@
         <div id="content" style="display: none">
           <div class="stats-header">
             <h2 id="stats-title">Today's Focus Switches</h2>
-            <button id="refresh-btn" aria-label="Refresh data" title="Refresh">🔄</button>
+            <button
+              id="refresh-btn"
+              aria-label="Refresh data"
+              title="Refresh data"
+              style="display: inline-flex; align-items: center; gap: 6px"
+            >
+              <span aria-hidden="true">🔄</span> <span class="icon-label">Refresh</span>
+            </button>
           </div>
 
           <div class="time-filter" role="tablist" aria-label="Time range filter">

--- a/src/popup/popup.js
+++ b/src/popup/popup.js
@@ -1,5 +1,48 @@
 import { setupVisualizationPage } from '../common/visualization-page.js';
+import { getSettings, updateSettings } from '../background/storage.js';
 
-document.addEventListener('DOMContentLoaded', () => {
+document.addEventListener('DOMContentLoaded', async () => {
+  const hcToggle = document.getElementById('high-contrast-toggle');
+  if (hcToggle) {
+    try {
+      const settings = await getSettings();
+      if (settings.highContrastMode) {
+        hcToggle.checked = true;
+        document.body.classList.add('high-contrast');
+      }
+    } catch (err) {
+      console.warn('Unable to load high-contrast setting', err);
+    }
+    hcToggle.addEventListener('change', async (e) => {
+      const enabled = e.target.checked;
+      try {
+        await updateSettings({ highContrastMode: enabled });
+      } catch (err) {
+        console.warn('Unable to save high-contrast setting', err);
+      }
+      document.body.classList.toggle('high-contrast', enabled);
+      const toast = document.getElementById('settings-toast');
+      if (toast) {
+        toast.textContent = enabled ? 'High contrast enabled' : 'High contrast disabled';
+        toast.classList.add('visible');
+        toast.style.display = 'block';
+        toast.style.opacity = '1';
+        setTimeout(() => {
+          toast.style.opacity = '0';
+          setTimeout(() => {
+            toast.classList.remove('visible');
+            toast.style.display = 'none';
+          }, 300);
+        }, 2000);
+      }
+    });
+  }
+  // Apply high-contrast on load even if toggle not present (for dashboard reuse)
+  try {
+    const s = await getSettings();
+    if (s.highContrastMode) document.body.classList.add('high-contrast');
+  } catch (err) {
+    console.warn('High-contrast init failed', err);
+  }
   setupVisualizationPage();
 });


### PR DESCRIPTION
Closes #51

**F-UX-001** Wire High-Contrast toggle: persist to `chrome.storage.local settings.highContrastMode` via getSettings/updateSettings, toggle `body.high-contrast`, toast feedback, apply on load for popup & dashboard; add CSS vars and .icon-label.

**F-UX-002** Dashboard Visits column now shows period count (`row.count`) matching header totals, not `todayCount`; sort fixed to sort on displayed field; header dynamically labeled Times Opened (Today/Week/Month).

**F-UX-003** Blocked countdown aligned with true reset via `getNextMidnight` (already) and now displays actual reset time (`formatResetTime`) in sublabel and footer for both daily and 5-hour limits.

**F-UX-004** Emoji toolbar buttons now have visible text labels (Blocks/Help/Settings/Refresh) with aria-hidden emoji + `.icon-label`, updated header styles to accommodate.

**F-UX-005** Insights converted from auto-opening modal overlay (fixed + 1s delay) to dismissible non-modal banner (inline, no overlay, immediate, Escape dismissible, persists `insightsDismissedDate`).

Krug: primary action per screen remains obvious. Empty/loading/error states retained.

Suite green; lint clean; build clean; tracked manifest untouched.