### PR TITLE
refactor(clean): split visualization god fn, named constants, fix comments (3.9) (#50)

### DIFF
--- a/src/background/badge.js
+++ b/src/background/badge.js
@@ -5,6 +5,9 @@
 
 import { getTodayVisitCount } from './storage.js';
 
+// Bright green accent used as the badge background.
+const FOCUS_BEAR_BADGE_COLOR = '#1BFF6E';
+
 /**
  * Update extension badge with current visit count
  */
@@ -17,7 +20,7 @@ export async function updateVisitBadge() {
     await chrome.action.setBadgeText({ text: badgeText });
 
     // Set badge background color using bright green accent
-    await chrome.action.setBadgeBackgroundColor({ color: '#1BFF6E' });
+    await chrome.action.setBadgeBackgroundColor({ color: FOCUS_BEAR_BADGE_COLOR });
 
     console.log(`Badge updated: ${count} visits tracked today`);
   } catch (error) {

--- a/src/background/limits.js
+++ b/src/background/limits.js
@@ -5,6 +5,9 @@
 
 import { getTodayKey, normalizeLimitConfig } from './storage.js';
 
+// One rolling 5-hour window used for the per-window visit counter.
+const FIVE_HOURS_MS = 5 * 60 * 60 * 1000;
+
 function getNextActiveLimit(normalizedConfig, fiveHourCount, dailyCount) {
   const candidates = [];
   if (normalizedConfig.fiveHour.enabled) {
@@ -127,8 +130,7 @@ export async function checkLimit(domain) {
       }
 
       // Check 5-hour window limit
-      const fiveHourMs = 5 * 60 * 60 * 1000;
-      const fiveHourCount = countVisitsInWindow(timestamps, fiveHourMs);
+      const fiveHourCount = countVisitsInWindow(timestamps, FIVE_HOURS_MS);
 
       if (limitConfig.fiveHour.enabled && fiveHourCount >= limitConfig.fiveHour.limit) {
         resolve({
@@ -234,11 +236,10 @@ export async function updateBlockingRules() {
       }
 
       // Check 5-hour window
-      const fiveHourMs = 5 * 60 * 60 * 1000;
-      const fiveHourCount = countVisitsInWindow(timestamps, fiveHourMs);
+      const fiveHourCount = countVisitsInWindow(timestamps, FIVE_HOURS_MS);
 
       if (normalizedConfig.fiveHour.enabled && fiveHourCount >= normalizedConfig.fiveHour.limit) {
-        const oldestTimestamp = getOldestTimestampInWindow(timestamps, fiveHourMs);
+        const oldestTimestamp = getOldestTimestampInWindow(timestamps, FIVE_HOURS_MS);
         console.info('[Limits] Blocking domain due to 5h limit', {
           domain,
           fiveHourCount,

--- a/src/background/notifications.js
+++ b/src/background/notifications.js
@@ -226,9 +226,9 @@ export async function clearNotificationHistory() {
  * Initialize notification system
  */
 export async function initializeNotifications() {
-  // Ensure preferences exist
+  // Ensure preferences exist (seed defaults if `enabled` was never set)
   const preferences = await getNotificationPreferences();
-  if (!preferences.enabled && preferences.enabled !== false) {
+  if (preferences.enabled === undefined) {
     await setNotificationPreferences(DEFAULT_PREFERENCES);
   }
 

--- a/src/common/visualization-page.js
+++ b/src/common/visualization-page.js
@@ -17,6 +17,9 @@ import { updateBlockingRules } from '../background/limits.js';
 import { getTodayKey, aggregateVisitsInRange } from './date-utils.js';
 import { validateLimitConfig, validateDomain } from './limit-validation.js';
 
+// "Near limit" threshold: 80% of a configured limit triggers the near-limit warning.
+const NEAR_LIMIT_THRESHOLD = 0.8;
+
 /**
  * Load aggregated stats for a given time range
  * Recreates the getAggregatedStats function from storage.js for use in the UI
@@ -169,8 +172,8 @@ function generateInsightsSummary(aggregatedData, limits, range, previousData = n
     // Determine if over or near limit (check both)
     const overFiveHour = fiveHourLimit && fiveHourCount >= fiveHourLimit;
     const overDaily = dailyLimit && todayCount >= dailyLimit;
-    const nearFiveHour = fiveHourLimit && fiveHourCount >= fiveHourLimit * 0.8;
-    const nearDaily = dailyLimit && todayCount >= dailyLimit * 0.8;
+    const nearFiveHour = fiveHourLimit && fiveHourCount >= fiveHourLimit * NEAR_LIMIT_THRESHOLD;
+    const nearDaily = dailyLimit && todayCount >= dailyLimit * NEAR_LIMIT_THRESHOLD;
 
     if (overFiveHour || overDaily) {
       overLimitCount += 1;
@@ -334,86 +337,287 @@ export function generateWeeklyInsights(weekData, limits) {
 }
 
 /**
- * Wire up the visualization UI
- * @param {Object} options
+ * Build the shared DOM/UI context used by the three `wireVisualization*` helpers.
+ * All mutable state (current range, pending graph cleanup, toast timer) lives here
+ * so each helper stays small and single-purpose.
+ * @param {Object} options - setupVisualizationPage options
+ * @returns {Object} shared context passed to helpers
  */
-export async function setupVisualizationPage(options = {}) {
-  const {
-    defaultRange = 'today',
-    graphDimensions = {},
-    listLimit = 10,
-    fullPage = false,
-    onDataLoaded = null,
-  } = options;
+function buildVisualizationContext(options) {
+  return {
+    // Mutable state
+    currentRange: options.defaultRange || 'today',
+    cleanupGraph: null,
+    toastTimeout: null,
+    resetConfirmTimeout: null,
+    // Static options consumed by render
+    graphWidth: options.graphDimensions?.width || 400,
+    graphHeight: options.graphDimensions?.height || 450,
+    listLimit: options.listLimit || 10,
+    onDataLoaded: options.onDataLoaded || null,
+    // Cached DOM refs
+    dom: {
+      loading: document.getElementById('loading'),
+      mainView: document.getElementById('main-view'),
+      settingsView: document.getElementById('settings-view'),
+      settingsBtn: document.getElementById('settings-btn'),
+      settingsBackBtn: document.getElementById('settings-back-btn'),
+      settingsToast: document.getElementById('settings-toast'),
+      limitForm: document.getElementById('limit-form'),
+      limitErrorEl: document.getElementById('limit-error'),
+      limitList: document.getElementById('limit-list'),
+      limitsEmpty: document.getElementById('limits-empty'),
+      resetDataBtn: document.getElementById('reset-data-btn'),
+      exportJsonBtn: document.getElementById('export-json-btn'),
+      exportCsvBtn: document.getElementById('export-csv-btn'),
+    },
+  };
+}
 
-  const graphWidth = graphDimensions.width || 400;
-  const graphHeight = graphDimensions.height || 450;
+/**
+ * Wire the render side: simple list, quick-limits panel, and the main render
+ * pipeline that drives the radial graph (or the fallback list) for a given range.
+ * @param {Object} ctx - shared visualization context
+ */
+function wireVisualizationRender(ctx) {
+  const renderSimpleList = (aggregatedVisits, domainListEl) => {
+    const sortedDomains = Object.keys(aggregatedVisits).sort(
+      (a, b) => aggregatedVisits[b].count - aggregatedVisits[a].count,
+    );
+    domainListEl.innerHTML = '';
+    sortedDomains.slice(0, ctx.listLimit).forEach((domain) => {
+      const domainData = aggregatedVisits[domain];
+      const item = document.createElement('div');
+      item.className = 'domain-item';
+      const info = document.createElement('div');
+      info.className = 'domain-info';
+      const name = document.createElement('div');
+      name.className = 'domain-name';
+      name.textContent = domain;
+      info.appendChild(name);
+      if (domainData.subpaths && Object.keys(domainData.subpaths).length > 0) {
+        const [topSubpath] = Object.entries(domainData.subpaths).sort(
+          (a, b) => b[1].count - a[1].count,
+        );
+        const subpathEl = document.createElement('div');
+        subpathEl.className = 'domain-subpath';
+        subpathEl.textContent = `Top: ${topSubpath[0]} (${topSubpath[1].count})`;
+        info.appendChild(subpathEl);
+      }
+      const count = document.createElement('div');
+      count.className = 'domain-count';
+      count.textContent = domainData.count;
+      count.setAttribute('aria-label', `${domainData.count} visits`);
+      item.append(info, count);
+      domainListEl.appendChild(item);
+    });
+  };
 
-  if (fullPage) {
-    document.body.classList.add('dashboard-view');
-  }
+  const renderQuickLimits = async (aggregatedVisits) => {
+    const panel = document.getElementById('quick-limits-panel');
+    const list = document.getElementById('quick-limits-list');
+    if (!panel || !list) return;
+    const topDomains = Object.entries(aggregatedVisits)
+      .sort(([, a], [, b]) => b.count - a.count)
+      .slice(0, 5)
+      .map(([d]) => d);
+    if (topDomains.length === 0) {
+      panel.style.display = 'none';
+      return;
+    }
+    panel.style.display = 'block';
+    list.innerHTML = '';
+    const limits = await getLimits();
+    const defaultConfig = createDefaultLimitConfig();
+    topDomains.forEach((domain) => {
+      const limitConfig = limits[domain] ? normalizeLimitConfig(limits[domain]) : null;
+      const hasLimit = limitConfig !== null;
+      const isEnabled = hasLimit && limitConfig.enabled;
+      const visitCount = aggregatedVisits[domain].count;
 
-  let currentRange = defaultRange;
-  let cleanupGraph = null;
-  let toastTimeout = null;
+      const item = document.createElement('li');
+      item.className = 'quick-limit-item';
+      const info = document.createElement('div');
+      info.className = 'quick-limit-info';
+      const domainDiv = document.createElement('div');
+      domainDiv.className = 'quick-limit-domain';
+      domainDiv.textContent = domain;
+      const statsDiv = document.createElement('div');
+      statsDiv.className = 'quick-limit-stats';
+      const visitSpan = document.createElement('span');
+      visitSpan.className = 'visit-count';
+      visitSpan.textContent = `${visitCount} visits`;
+      statsDiv.appendChild(visitSpan);
+      const statusSpan = document.createElement('span');
+      if (!hasLimit) {
+        statusSpan.className = 'limit-status no-limit';
+        statusSpan.textContent = `Default ${defaultConfig.fiveHour.limit}/5h \u00B7 ${defaultConfig.daily.limit}/day`;
+      } else if (!isEnabled) {
+        statusSpan.className = 'limit-status disabled';
+        statusSpan.textContent = 'Disabled';
+      } else {
+        const parts = [];
+        if (limitConfig.fiveHour.enabled) parts.push(`${limitConfig.fiveHour.limit}/5h`);
+        if (limitConfig.daily.enabled) parts.push(`${limitConfig.daily.limit}/day`);
+        statusSpan.className = 'limit-status active';
+        statusSpan.textContent = parts.join(', ');
+      }
+      statsDiv.appendChild(document.createTextNode(' '));
+      statsDiv.appendChild(statusSpan);
+      info.append(domainDiv, statsDiv);
 
-  const loading = document.getElementById('loading');
-  const mainView = document.getElementById('main-view');
-  const settingsView = document.getElementById('settings-view');
-  const settingsBtn = document.getElementById('settings-btn');
-  const settingsBackBtn = document.getElementById('settings-back-btn');
-  const limitForm = document.getElementById('limit-form');
-  const limitErrorEl = document.getElementById('limit-error');
-  const limitList = document.getElementById('limit-list');
-  const limitsEmpty = document.getElementById('limits-empty');
-  const settingsToast = document.getElementById('settings-toast');
-  const resetDataBtn = document.getElementById('reset-data-btn');
+      const actions = document.createElement('div');
+      actions.className = 'quick-limit-actions';
+      const toggleWrapper = document.createElement('label');
+      toggleWrapper.className = 'quick-limit-toggle';
+      toggleWrapper.setAttribute('aria-label', `Toggle limit for ${domain}`);
+      const toggleInput = document.createElement('input');
+      toggleInput.type = 'checkbox';
+      toggleInput.checked = isEnabled;
+      toggleInput.dataset.domain = domain;
+      toggleInput.dataset.action = 'quick-toggle';
+      toggleInput.dataset.state = hasLimit ? 'configured' : 'default';
+      toggleWrapper.appendChild(toggleInput);
+      actions.appendChild(toggleWrapper);
+      const customizeBtn = document.createElement('button');
+      customizeBtn.type = 'button';
+      customizeBtn.className = 'pill-button pill-button-secondary pill-button-small';
+      customizeBtn.dataset.domain = domain;
+      customizeBtn.dataset.action = 'quick-customize';
+      customizeBtn.textContent = 'Customize';
+      customizeBtn.setAttribute('aria-label', `Customize limit for ${domain}`);
+      actions.appendChild(customizeBtn);
+      item.append(info, actions);
+      list.appendChild(item);
+    });
+  };
+
+  ctx.renderVisualization = async (range = ctx.currentRange) => {
+    const graphContainer = document.getElementById('graph-container');
+    const domainListEl = document.getElementById('domain-list');
+    const emptyState = document.getElementById('empty-state');
+    const content = document.getElementById('content');
+    const title = document.getElementById('stats-title');
+
+    try {
+      if (title) title.textContent = getTitleForRange(range);
+      const aggregatedVisits = await loadAggregatedStats(range);
+      const domains = Object.keys(aggregatedVisits);
+      if (domains.length === 0) {
+        if (emptyState) emptyState.style.display = 'block';
+        if (content) content.style.display = 'none';
+        if (ctx.onDataLoaded) ctx.onDataLoaded({});
+        return;
+      }
+      if (emptyState) emptyState.style.display = 'none';
+      if (content) content.style.display = 'block';
+      if (ctx.onDataLoaded) ctx.onDataLoaded(aggregatedVisits);
+      await renderQuickLimits(aggregatedVisits);
+
+      if (ctx.cleanupGraph) {
+        ctx.cleanupGraph();
+        ctx.cleanupGraph = null;
+      }
+
+      if (isFeatureEnabled('RADIAL_GRAPH')) {
+        if (graphContainer) graphContainer.style.display = 'block';
+        if (domainListEl) domainListEl.style.display = 'none';
+        const badges = await calculateFocusHeroBadges();
+        const limits = await getLimits();
+        ctx.cleanupGraph = renderRadialGraph(graphContainer, aggregatedVisits, {
+          width: ctx.graphWidth,
+          height: ctx.graphHeight,
+          badges,
+          limits,
+        });
+        const summaryElement = document.getElementById('summary-content');
+        if (summaryElement) {
+          const comparisonToggle = document.getElementById('comparison-toggle-input');
+          const isComparisonEnabled = comparisonToggle && comparisonToggle.checked;
+          const previousData = isComparisonEnabled
+            ? await loadPreviousPeriodData(ctx.currentRange)
+            : null;
+          const summaryText = generateInsightsSummary(
+            aggregatedVisits,
+            limits,
+            ctx.currentRange,
+            previousData,
+          );
+          summaryElement.classList.add('updating');
+          summaryElement.textContent = summaryText;
+          setTimeout(() => summaryElement.classList.remove('updating'), 300);
+        }
+      } else if (graphContainer && domainListEl) {
+        graphContainer.style.display = 'none';
+        domainListEl.style.display = 'block';
+        renderSimpleList(aggregatedVisits, domainListEl);
+      }
+    } catch (error) {
+      console.error('Error rendering visualization:', error);
+      console.error('Error stack:', error.stack);
+      if (graphContainer) {
+        graphContainer.replaceChildren();
+        const errorDiv = document.createElement('div');
+        errorDiv.className = 'graph-error';
+        errorDiv.appendChild(document.createTextNode('Error loading visualization'));
+        errorDiv.appendChild(document.createElement('br'));
+        const small = document.createElement('small');
+        small.style.fontSize = '11px';
+        small.style.opacity = '0.7';
+        small.textContent = error.message;
+        errorDiv.appendChild(small);
+        graphContainer.appendChild(errorDiv);
+      }
+    }
+  };
+}
+
+/**
+ * Wire the settings view: limit list, limit form, toasts, view navigation, and
+ * the destructive reset-data button. Returns helpers the other wirers call.
+ * @param {Object} ctx - shared visualization context
+ */
+function wireVisualizationSettings(ctx) {
+  const { dom } = ctx;
+
+  const showSettingsToast = (message) => {
+    if (!dom.settingsToast) return;
+    dom.settingsToast.textContent = message;
+    dom.settingsToast.classList.add('visible');
+    if (ctx.toastTimeout) clearTimeout(ctx.toastTimeout);
+    ctx.toastTimeout = setTimeout(() => {
+      dom.settingsToast.classList.remove('visible');
+    }, 3500);
+  };
 
   const applyLimitConfigToForm = (domainValue, config) => {
-    if (!limitForm) return;
-    const resolvedConfig = config ? normalizeLimitConfig(config) : createDefaultLimitConfig();
-    limitForm.elements.domain.value = domainValue || '';
-    limitForm.elements.enabled.checked = resolvedConfig.enabled;
-    limitForm.elements.fiveHourEnabled.checked = resolvedConfig.fiveHour.enabled;
-    limitForm.elements.fiveHourLimit.value = resolvedConfig.fiveHour.limit;
-    limitForm.elements.dailyEnabled.checked = resolvedConfig.daily.enabled;
-    limitForm.elements.dailyLimit.value = resolvedConfig.daily.limit;
+    if (!dom.limitForm) return;
+    const resolved = config ? normalizeLimitConfig(config) : createDefaultLimitConfig();
+    dom.limitForm.elements.domain.value = domainValue || '';
+    dom.limitForm.elements.enabled.checked = resolved.enabled;
+    dom.limitForm.elements.fiveHourEnabled.checked = resolved.fiveHour.enabled;
+    dom.limitForm.elements.fiveHourLimit.value = resolved.fiveHour.limit;
+    dom.limitForm.elements.dailyEnabled.checked = resolved.daily.enabled;
+    dom.limitForm.elements.dailyLimit.value = resolved.daily.limit;
   };
 
   const resetLimitFormToDefaults = () => {
     applyLimitConfigToForm('', createDefaultLimitConfig());
   };
 
-  const showSettingsToast = (message) => {
-    if (!settingsToast) return;
-    settingsToast.textContent = message;
-    settingsToast.classList.add('visible');
-    if (toastTimeout) {
-      clearTimeout(toastTimeout);
-    }
-    toastTimeout = setTimeout(() => {
-      settingsToast.classList.remove('visible');
-    }, 3500);
-  };
-
   const refreshLimitList = async () => {
-    if (!limitList) return;
+    if (!dom.limitList) return;
     const limits = await getLimits();
     const entries = Object.entries(limits);
-    limitList.innerHTML = '';
-    if (limitsEmpty) {
-      limitsEmpty.hidden = entries.length > 0;
-    }
-    if (entries.length === 0) {
-      return;
-    }
+    dom.limitList.innerHTML = '';
+    if (dom.limitsEmpty) dom.limitsEmpty.hidden = entries.length > 0;
+    if (entries.length === 0) return;
 
     entries.forEach(([domain, limitConfig]) => {
       const normalized = normalizeLimitConfig(limitConfig);
       const item = document.createElement('li');
       const info = document.createElement('div');
       info.className = 'limit-item-info';
-
       const domainStrong = document.createElement('strong');
       domainStrong.textContent = domain;
       info.appendChild(domainStrong);
@@ -424,12 +628,8 @@ export async function setupVisualizationPage(options = {}) {
         limitSpan.style.color = '#999';
       } else {
         const parts = [];
-        if (normalized.fiveHour.enabled) {
-          parts.push(`${normalized.fiveHour.limit} per 5h`);
-        }
-        if (normalized.daily.enabled) {
-          parts.push(`${normalized.daily.limit} per day`);
-        }
+        if (normalized.fiveHour.enabled) parts.push(`${normalized.fiveHour.limit} per 5h`);
+        if (normalized.daily.enabled) parts.push(`${normalized.daily.limit} per day`);
         if (parts.length === 0) {
           limitSpan.textContent = 'No limits active';
           limitSpan.style.color = '#999';
@@ -439,17 +639,14 @@ export async function setupVisualizationPage(options = {}) {
       }
       info.appendChild(limitSpan);
 
-      // Quick toggle switch
       const toggleWrapper = document.createElement('label');
       toggleWrapper.className = 'limit-item-toggle';
       toggleWrapper.setAttribute('aria-label', `Toggle limit for ${domain}`);
-
       const toggleInput = document.createElement('input');
       toggleInput.type = 'checkbox';
       toggleInput.checked = normalized.enabled;
       toggleInput.dataset.domain = domain;
       toggleInput.dataset.action = 'toggle';
-
       toggleWrapper.appendChild(toggleInput);
 
       const editBtn = document.createElement('button');
@@ -471,492 +668,148 @@ export async function setupVisualizationPage(options = {}) {
       const btnGroup = document.createElement('div');
       btnGroup.className = 'limit-item-actions';
       btnGroup.append(toggleWrapper, editBtn, removeBtn);
-
       item.append(info, btnGroup);
-      limitList.appendChild(item);
+      dom.limitList.appendChild(item);
     });
   };
 
   const showSettingsView = async () => {
-    if (!settingsView || !mainView) return;
-    mainView.style.display = 'none';
-    settingsView.hidden = false;
-    settingsView.setAttribute('aria-hidden', 'false');
-    settingsView.focus();
+    if (!dom.settingsView || !dom.mainView) return;
+    dom.mainView.style.display = 'none';
+    dom.settingsView.hidden = false;
+    dom.settingsView.setAttribute('aria-hidden', 'false');
+    dom.settingsView.focus();
     await refreshLimitList();
   };
 
   const showMainView = () => {
-    if (!settingsView || !mainView) return;
-    settingsView.hidden = true;
-    settingsView.setAttribute('aria-hidden', 'true');
-    mainView.style.display = 'block';
+    if (!dom.settingsView || !dom.mainView) return;
+    dom.settingsView.hidden = true;
+    dom.settingsView.setAttribute('aria-hidden', 'true');
+    dom.mainView.style.display = 'block';
   };
 
-  const renderSimpleList = (aggregatedVisits, domainListEl) => {
-    const sortedDomains = Object.keys(aggregatedVisits).sort(
-      (a, b) => aggregatedVisits[b].count - aggregatedVisits[a].count,
-    );
-
-    domainListEl.innerHTML = '';
-
-    const topDomains = sortedDomains.slice(0, listLimit);
-    topDomains.forEach((domain) => {
-      const domainData = aggregatedVisits[domain];
-
-      const item = document.createElement('div');
-      item.className = 'domain-item';
-
-      const info = document.createElement('div');
-      info.className = 'domain-info';
-
-      const name = document.createElement('div');
-      name.className = 'domain-name';
-      name.textContent = domain;
-      info.appendChild(name);
-
-      if (domainData.subpaths && Object.keys(domainData.subpaths).length > 0) {
-        const subpaths = Object.entries(domainData.subpaths);
-        const topSubpath = subpaths.sort((a, b) => b[1].count - a[1].count)[0];
-
-        const subpathEl = document.createElement('div');
-        subpathEl.className = 'domain-subpath';
-        subpathEl.textContent = `Top: ${topSubpath[0]} (${topSubpath[1].count})`;
-        info.appendChild(subpathEl);
-      }
-
-      const count = document.createElement('div');
-      count.className = 'domain-count';
-      count.textContent = domainData.count;
-      count.setAttribute('aria-label', `${domainData.count} visits`);
-
-      item.append(info, count);
-      domainListEl.appendChild(item);
-    });
-  };
-
-  const renderQuickLimits = async (aggregatedVisits) => {
-    const quickLimitsPanel = document.getElementById('quick-limits-panel');
-    const quickLimitsList = document.getElementById('quick-limits-list');
-
-    if (!quickLimitsPanel || !quickLimitsList) return;
-
-    // Get top 5 domains by visit count
-    const sortedDomains = Object.entries(aggregatedVisits)
-      .sort(([, a], [, b]) => b.count - a.count)
-      .slice(0, 5)
-      .map(([domain]) => domain);
-
-    if (sortedDomains.length === 0) {
-      quickLimitsPanel.style.display = 'none';
-      return;
-    }
-
-    quickLimitsPanel.style.display = 'block';
-    quickLimitsList.innerHTML = '';
-
-    const limits = await getLimits();
-
-    sortedDomains.forEach((domain) => {
-      const visitCount = aggregatedVisits[domain].count;
-      const limitConfig = limits[domain] ? normalizeLimitConfig(limits[domain]) : null;
-      const defaultConfig = createDefaultLimitConfig();
-      const hasLimit = limitConfig !== null;
-      const isEnabled = hasLimit && limitConfig.enabled;
-
-      const item = document.createElement('li');
-      item.className = 'quick-limit-item';
-
-      const info = document.createElement('div');
-      info.className = 'quick-limit-info';
-
-      const domainDiv = document.createElement('div');
-      domainDiv.className = 'quick-limit-domain';
-      domainDiv.textContent = domain;
-
-      const statsDiv = document.createElement('div');
-      statsDiv.className = 'quick-limit-stats';
-      const visitSpan = document.createElement('span');
-      visitSpan.className = 'visit-count';
-      visitSpan.textContent = `${visitCount} visits`;
-      statsDiv.appendChild(visitSpan);
-
-      const statusSpan = document.createElement('span');
-      if (!hasLimit) {
-        statusSpan.className = 'limit-status no-limit';
-        statusSpan.textContent = `Default ${defaultConfig.fiveHour.limit}/5h \u00B7 ${defaultConfig.daily.limit}/day`;
-      } else if (!isEnabled) {
-        statusSpan.className = 'limit-status disabled';
-        statusSpan.textContent = 'Disabled';
-      } else {
-        const parts = [];
-        if (limitConfig.fiveHour.enabled) {
-          parts.push(`${limitConfig.fiveHour.limit}/5h`);
-        }
-        if (limitConfig.daily.enabled) {
-          parts.push(`${limitConfig.daily.limit}/day`);
-        }
-        statusSpan.className = 'limit-status active';
-        statusSpan.textContent = parts.join(', ');
-      }
-      statsDiv.appendChild(document.createTextNode(' '));
-      statsDiv.appendChild(statusSpan);
-
-      info.append(domainDiv, statsDiv);
-
-      const actions = document.createElement('div');
-      actions.className = 'quick-limit-actions';
-
-      // Toggle switch
-      const toggleWrapper = document.createElement('label');
-      toggleWrapper.className = 'quick-limit-toggle';
-      toggleWrapper.setAttribute('aria-label', `Toggle limit for ${domain}`);
-
-      const toggleInput = document.createElement('input');
-      toggleInput.type = 'checkbox';
-      toggleInput.checked = isEnabled;
-      toggleInput.dataset.domain = domain;
-      toggleInput.dataset.action = 'quick-toggle';
-      toggleInput.dataset.state = hasLimit ? 'configured' : 'default';
-
-      toggleWrapper.appendChild(toggleInput);
-      actions.appendChild(toggleWrapper);
-
-      const customizeBtn = document.createElement('button');
-      customizeBtn.type = 'button';
-      customizeBtn.className = 'pill-button pill-button-secondary pill-button-small';
-      customizeBtn.dataset.domain = domain;
-      customizeBtn.dataset.action = 'quick-customize';
-      customizeBtn.textContent = 'Customize';
-      customizeBtn.setAttribute('aria-label', `Customize limit for ${domain}`);
-      actions.appendChild(customizeBtn);
-
-      item.append(info, actions);
-      quickLimitsList.appendChild(item);
-    });
-  };
-
-  const renderVisualization = async (range = currentRange) => {
-    const graphContainer = document.getElementById('graph-container');
-    const domainListEl = document.getElementById('domain-list');
-    const emptyState = document.getElementById('empty-state');
-    const content = document.getElementById('content');
-    const title = document.getElementById('stats-title');
-
-    try {
-      if (title) {
-        title.textContent = getTitleForRange(range);
-      }
-
-      const aggregatedVisits = await loadAggregatedStats(range);
-
-      const domains = Object.keys(aggregatedVisits);
-      if (domains.length === 0) {
-        if (emptyState) emptyState.style.display = 'block';
-        if (content) content.style.display = 'none';
-        // Call callback with empty data
-        if (onDataLoaded) {
-          onDataLoaded({});
-        }
-        return;
-      }
-
-      if (emptyState) emptyState.style.display = 'none';
-      if (content) content.style.display = 'block';
-
-      // Call data loaded callback
-      if (onDataLoaded) {
-        onDataLoaded(aggregatedVisits);
-      }
-
-      // Render quick limits panel
-      await renderQuickLimits(aggregatedVisits);
-
-      if (cleanupGraph) {
-        cleanupGraph();
-        cleanupGraph = null;
-      }
-
-      if (isFeatureEnabled('RADIAL_GRAPH')) {
-        if (graphContainer) {
-          graphContainer.style.display = 'block';
-        }
-        if (domainListEl) {
-          domainListEl.style.display = 'none';
-        }
-
-        // Calculate Focus Hero badges and get limits for color-coding
-        const badges = await calculateFocusHeroBadges();
-        const limits = await getLimits();
-
-        cleanupGraph = renderRadialGraph(graphContainer, aggregatedVisits, {
-          width: graphWidth,
-          height: graphHeight,
-          badges,
-          limits,
-        });
-
-        // Update graph summary (if element exists - dashboard only)
-        const summaryElement = document.getElementById('summary-content');
-        if (summaryElement) {
-          // Load comparison data if toggle is enabled
-          const comparisonToggle = document.getElementById('comparison-toggle-input');
-          const isComparisonEnabled = comparisonToggle && comparisonToggle.checked;
-          const previousData = isComparisonEnabled
-            ? await loadPreviousPeriodData(currentRange)
-            : null;
-
-          const summaryText = generateInsightsSummary(
-            aggregatedVisits,
-            limits,
-            currentRange,
-            previousData,
-          );
-          summaryElement.classList.add('updating');
-          summaryElement.textContent = summaryText;
-          // Remove animation class after animation completes
-          setTimeout(() => {
-            summaryElement.classList.remove('updating');
-          }, 300);
-        }
-      } else {
-        if (graphContainer) {
-          graphContainer.style.display = 'none';
-        }
-        if (domainListEl) {
-          domainListEl.style.display = 'block';
-          renderSimpleList(aggregatedVisits, domainListEl);
-        }
-      }
-    } catch (error) {
-      console.error('Error rendering visualization:', error);
-      console.error('Error stack:', error.stack);
-      if (graphContainer) {
-        graphContainer.replaceChildren();
-        const errorDiv = document.createElement('div');
-        errorDiv.className = 'graph-error';
-        errorDiv.appendChild(document.createTextNode('Error loading visualization'));
-        errorDiv.appendChild(document.createElement('br'));
-        const small = document.createElement('small');
-        small.style.fontSize = '11px';
-        small.style.opacity = '0.7';
-        small.textContent = error.message;
-        errorDiv.appendChild(small);
-        graphContainer.appendChild(errorDiv);
-      }
-    }
-  };
-
-  const timeFilterBtns = document.querySelectorAll('.time-filter-btn');
-  timeFilterBtns.forEach((btn) => {
-    btn.addEventListener('click', async () => {
-      const { range } = btn.dataset;
-      currentRange = range;
-
-      timeFilterBtns.forEach((b) => {
-        b.classList.remove('active');
-        b.setAttribute('aria-selected', 'false');
-      });
-
-      btn.classList.add('active');
-      btn.setAttribute('aria-selected', 'true');
-
-      await renderVisualization(range);
-    });
-  });
-
-  // Comparison toggle handler
-  const comparisonToggle = document.getElementById('comparison-toggle-input');
-  if (comparisonToggle) {
-    comparisonToggle.addEventListener('change', async () => {
-      const comparisonColumns = document.querySelectorAll('.comparison-column');
-      comparisonColumns.forEach((col) => {
-        col.style.display = comparisonToggle.checked ? '' : 'none';
-      });
-
-      // Refresh visualization to include comparison data
-      await renderVisualization(currentRange);
-    });
+  // Settings/main view navigation
+  if (dom.settingsBtn && dom.settingsView && dom.mainView) {
+    dom.settingsBtn.addEventListener('click', showSettingsView);
+  }
+  if (dom.settingsBackBtn) {
+    dom.settingsBackBtn.addEventListener('click', showMainView);
   }
 
-  const refreshBtn = document.getElementById('refresh-btn');
-  if (refreshBtn) {
-    refreshBtn.addEventListener('click', async () => {
-      await renderVisualization(currentRange);
-    });
-  }
-
-  if (settingsBtn && settingsView && mainView) {
-    settingsBtn.addEventListener('click', async () => {
-      await showSettingsView();
-    });
-  }
-
-  if (settingsBackBtn) {
-    settingsBackBtn.addEventListener('click', () => {
-      showMainView();
-    });
-  }
-
-  if (limitList) {
-    limitList.addEventListener('click', async (event) => {
+  // Limit list interactions (toggle / remove / edit)
+  if (dom.limitList) {
+    dom.limitList.addEventListener('click', async (event) => {
       const { domain, action } = event.target.dataset || {};
       if (!domain || !action) return;
-
       if (action === 'toggle') {
-        // Quick toggle to enable/disable limits
         try {
           const limits = await getLimits();
           const limitConfig = normalizeLimitConfig(limits[domain]);
-
-          // Toggle the enabled state
           const newEnabled = event.target.checked;
           limitConfig.enabled = newEnabled;
-
           await setLimitForDomain(domain, limitConfig);
-
-          // Update blocking rules to reflect the limit change
           await updateBlockingRules();
-
           await refreshLimitList();
           showSettingsToast(`${domain} limits ${newEnabled ? 'enabled' : 'disabled'}`);
         } catch (error) {
           console.error('Unable to toggle limit:', error);
-          // Revert checkbox state
           event.target.checked = !event.target.checked;
           showSettingsToast('Unable to toggle that limit.');
         }
       } else if (action === 'remove') {
         try {
           await setLimitForDomain(domain, null);
-
-          // Update blocking rules to reflect the limit removal
           await updateBlockingRules();
-
           await refreshLimitList();
           showSettingsToast(`Removed limit for ${domain}`);
         } catch (error) {
           console.error('Unable to remove limit:', error);
           showSettingsToast('Unable to remove that limit.');
         }
-      } else if (action === 'edit') {
-        // Populate form with existing limit data
+      } else if (action === 'edit' && dom.limitForm) {
         const limits = await getLimits();
         const limitConfig = normalizeLimitConfig(limits[domain]);
-
-        if (limitForm) {
-          applyLimitConfigToForm(domain, limitConfig);
-
-          // Scroll to form
-          limitForm.scrollIntoView({ behavior: 'smooth', block: 'start' });
-          limitForm.elements.domain.focus();
-        }
+        applyLimitConfigToForm(domain, limitConfig);
+        dom.limitForm.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        dom.limitForm.elements.domain.focus();
       }
     });
   }
 
-  // Quick limits panel event handlers
-  const quickLimitsList = document.getElementById('quick-limits-list');
-  if (quickLimitsList) {
-    quickLimitsList.addEventListener('click', async (event) => {
-      const { domain, action } = event.target.dataset || {};
-      if (!domain || !action) return;
-
-      if (action === 'quick-toggle') {
-        // Quick toggle to enable/disable limits
-        const desiredState = event.target.checked;
-        try {
-          const limits = await getLimits();
-          let limitConfig = limits[domain] ? normalizeLimitConfig(limits[domain]) : null;
-
-          // Toggle the enabled state
-          const newEnabled = desiredState;
-
-          if (!limitConfig && newEnabled) {
-            limitConfig = createDefaultLimitConfig();
-          }
-
-          if (!limitConfig) {
-            event.target.checked = false;
-            return;
-          }
-
-          limitConfig.enabled = newEnabled;
-
-          await setLimitForDomain(domain, limitConfig);
-
-          // Update blocking rules to reflect the limit change
-          await updateBlockingRules();
-
-          await renderVisualization(currentRange);
-        } catch (error) {
-          console.error('Unable to toggle limit:', error);
-          // Revert checkbox state
-          event.target.checked = !desiredState;
-        }
-      } else if (action === 'quick-customize') {
-        // Open settings and populate form with this domain
-        await showSettingsView();
-
-        if (limitForm) {
-          const limits = await getLimits();
-          const limitConfig = limits[domain]
-            ? normalizeLimitConfig(limits[domain])
-            : createDefaultLimitConfig();
-          applyLimitConfigToForm(domain, limitConfig);
-
-          // Scroll to form
-          limitForm.scrollIntoView({ behavior: 'smooth', block: 'start' });
-          limitForm.elements.domain.focus();
-        }
-      }
+  // Limit form (create/update) interactions + destructive reset button are
+  // delegated to a dedicated wirer to keep this function under ~200 lines.
+  if (dom.limitForm || dom.resetDataBtn) {
+    wireLimitFormAndReset({
+      ctx,
+      dom,
+      resetLimitFormToDefaults,
+      refreshLimitList,
+      showSettingsToast,
     });
   }
 
-  if (limitForm) {
+  // Expose helpers consumed by the actions wirer
+  ctx.showSettingsView = showSettingsView;
+  ctx.applyLimitConfigToForm = applyLimitConfigToForm;
+  ctx.showSettingsToast = showSettingsToast;
+}
+
+/**
+ * Wire the create/update limit form and the destructive reset-data button.
+ * Kept separate from `wireVisualizationSettings` so each named responsibility
+ * stays under ~200 lines.
+ * @param {Object} deps
+ * @param {Object} deps.ctx - shared visualization context
+ * @param {Object} deps.dom - cached DOM refs from ctx
+ * @param {Function} deps.resetLimitFormToDefaults
+ * @param {Function} deps.refreshLimitList
+ * @param {Function} deps.showSettingsToast
+ */
+function wireLimitFormAndReset({
+  ctx,
+  dom,
+  resetLimitFormToDefaults,
+  refreshLimitList,
+  showSettingsToast,
+}) {
+  if (dom.limitForm) {
     resetLimitFormToDefaults();
-    // Toggle visibility of limit config sections
-    const limitEnabledToggle = limitForm.elements.enabled;
-    const fiveHourEnabledToggle = limitForm.elements.fiveHourEnabled;
-    const dailyEnabledToggle = limitForm.elements.dailyEnabled;
+    const limitEnabledToggle = dom.limitForm.elements.enabled;
+    const fiveHourEnabledToggle = dom.limitForm.elements.fiveHourEnabled;
+    const dailyEnabledToggle = dom.limitForm.elements.dailyEnabled;
     const limitConfigSection = document.getElementById('limit-config-section');
     const fiveHourConfig = document.getElementById('five-hour-config');
     const dailyConfig = document.getElementById('daily-config');
-
     if (limitEnabledToggle && limitConfigSection) {
       limitEnabledToggle.addEventListener('change', () => {
         limitConfigSection.style.opacity = limitEnabledToggle.checked ? '1' : '0.5';
       });
     }
-
     if (fiveHourEnabledToggle && fiveHourConfig) {
       fiveHourEnabledToggle.addEventListener('change', () => {
         fiveHourConfig.style.opacity = fiveHourEnabledToggle.checked ? '1' : '0.5';
       });
     }
-
     if (dailyEnabledToggle && dailyConfig) {
       dailyEnabledToggle.addEventListener('change', () => {
         dailyConfig.style.opacity = dailyEnabledToggle.checked ? '1' : '0.5';
       });
     }
-
-    limitForm.addEventListener('submit', async (event) => {
+    dom.limitForm.addEventListener('submit', async (event) => {
       event.preventDefault();
-      const rawDomain = limitForm.elements.domain.value;
-      const enabled = limitForm.elements.enabled.checked;
-      const fiveHourEnabled = limitForm.elements.fiveHourEnabled.checked;
-      const fiveHourLimit = limitForm.elements.fiveHourLimit.value;
-      const dailyEnabled = limitForm.elements.dailyEnabled.checked;
-      const dailyLimit = limitForm.elements.dailyLimit.value;
+      const rawDomain = dom.limitForm.elements.domain.value;
+      const enabled = dom.limitForm.elements.enabled.checked;
+      const fiveHourEnabled = dom.limitForm.elements.fiveHourEnabled.checked;
+      const fiveHourLimit = dom.limitForm.elements.fiveHourLimit.value;
+      const dailyEnabled = dom.limitForm.elements.dailyEnabled.checked;
+      const dailyLimit = dom.limitForm.elements.dailyLimit.value;
 
       const domainRes = validateDomain(rawDomain);
       if (!domainRes.valid) {
-        if (limitErrorEl) limitErrorEl.textContent = domainRes.error;
+        if (dom.limitErrorEl) dom.limitErrorEl.textContent = domainRes.error;
         return;
       }
-      const normalizedDomain = domainRes.normalized;
-
       const limitRes = validateLimitConfig({
         fiveHourEnabled,
         fiveHourLimit,
@@ -964,13 +817,10 @@ export async function setupVisualizationPage(options = {}) {
         dailyLimit,
       });
       if (!limitRes.valid) {
-        if (limitErrorEl) limitErrorEl.textContent = limitRes.error;
+        if (dom.limitErrorEl) dom.limitErrorEl.textContent = limitRes.error;
         return;
       }
-
-      if (limitErrorEl) {
-        limitErrorEl.textContent = '';
-      }
+      if (dom.limitErrorEl) dom.limitErrorEl.textContent = '';
 
       try {
         const limitConfig = {
@@ -984,18 +834,12 @@ export async function setupVisualizationPage(options = {}) {
             limit: dailyEnabled ? Number(dailyLimit) : 20,
           },
         };
-
-        await setLimitForDomain(normalizedDomain, limitConfig);
-
-        // Update blocking rules to reflect the limit change
+        await setLimitForDomain(domainRes.normalized, limitConfig);
         await updateBlockingRules();
-
-        limitForm.reset();
-        // Restore default values after reset
+        dom.limitForm.reset();
         resetLimitFormToDefaults();
-
         await refreshLimitList();
-        showSettingsToast(`Limit saved for ${normalizedDomain}`);
+        showSettingsToast(`Limit saved for ${domainRes.normalized}`);
       } catch (error) {
         console.error('Unable to save limit:', error);
         showSettingsToast('Unable to save that limit.');
@@ -1003,28 +847,19 @@ export async function setupVisualizationPage(options = {}) {
     });
   }
 
-  if (resetDataBtn) {
-    const defaultResetLabel = resetDataBtn.textContent;
-    let resetConfirmTimeout = null;
-    resetDataBtn.addEventListener('click', async () => {
-      if (resetDataBtn.dataset.confirming === 'true') {
-        resetDataBtn.dataset.confirming = 'false';
-        resetDataBtn.textContent = defaultResetLabel;
-        if (resetConfirmTimeout) {
-          clearTimeout(resetConfirmTimeout);
-        }
+  if (dom.resetDataBtn) {
+    const defaultResetLabel = dom.resetDataBtn.textContent;
+    dom.resetDataBtn.addEventListener('click', async () => {
+      if (dom.resetDataBtn.dataset.confirming === 'true') {
+        dom.resetDataBtn.dataset.confirming = 'false';
+        dom.resetDataBtn.textContent = defaultResetLabel;
+        if (ctx.resetConfirmTimeout) clearTimeout(ctx.resetConfirmTimeout);
         try {
           await clearAllData();
-
-          // Clear all blocking rules since limits no longer exist
           await updateBlockingRules();
-
-          await updateSettings({
-            onboardingComplete: false,
-            defaultTimeRange: 'today',
-          });
+          await updateSettings({ onboardingComplete: false, defaultTimeRange: 'today' });
           await refreshLimitList();
-          await renderVisualization(currentRange);
+          await ctx.renderVisualization(ctx.currentRange);
           showSettingsToast('All focus data cleared.');
         } catch (error) {
           console.error('Unable to reset data:', error);
@@ -1032,135 +867,216 @@ export async function setupVisualizationPage(options = {}) {
         }
         return;
       }
-
-      resetDataBtn.dataset.confirming = 'true';
-      resetDataBtn.textContent = 'Tap again to confirm reset';
+      dom.resetDataBtn.dataset.confirming = 'true';
+      dom.resetDataBtn.textContent = 'Tap again to confirm reset';
       showSettingsToast('Tap again to confirm reset.');
-      resetConfirmTimeout = setTimeout(() => {
-        resetDataBtn.dataset.confirming = 'false';
-        resetDataBtn.textContent = defaultResetLabel;
+      ctx.resetConfirmTimeout = setTimeout(() => {
+        dom.resetDataBtn.dataset.confirming = 'false';
+        dom.resetDataBtn.textContent = defaultResetLabel;
       }, 4000);
     });
   }
+}
 
-  // Export data handlers
-  const exportJsonBtn = document.getElementById('export-json-btn');
-  const exportCsvBtn = document.getElementById('export-csv-btn');
+/**
+ * Wire the remaining top-level actions: time-filter, comparison toggle, refresh,
+ * quick-limits panel, export buttons, drilldown event, and the initial render
+ * + performance log.
+ * @param {Object} ctx - shared visualization context
+ * @param {Object} options - original setupVisualizationPage options
+ */
+async function wireVisualizationActions(ctx, _options) {
+  const { dom } = ctx;
 
-  if (exportJsonBtn) {
-    exportJsonBtn.addEventListener('click', async () => {
+  // Time filter buttons
+  document.querySelectorAll('.time-filter-btn').forEach((btn) => {
+    btn.addEventListener('click', async () => {
+      const { range } = btn.dataset;
+      ctx.currentRange = range;
+      document.querySelectorAll('.time-filter-btn').forEach((b) => {
+        b.classList.remove('active');
+        b.setAttribute('aria-selected', 'false');
+      });
+      btn.classList.add('active');
+      btn.setAttribute('aria-selected', 'true');
+      await ctx.renderVisualization(range);
+    });
+  });
+
+  // Comparison toggle
+  const comparisonToggle = document.getElementById('comparison-toggle-input');
+  if (comparisonToggle) {
+    comparisonToggle.addEventListener('change', async () => {
+      document.querySelectorAll('.comparison-column').forEach((col) => {
+        col.style.display = comparisonToggle.checked ? '' : 'none';
+      });
+      await ctx.renderVisualization(ctx.currentRange);
+    });
+  }
+
+  // Refresh button
+  const refreshBtn = document.getElementById('refresh-btn');
+  if (refreshBtn) {
+    refreshBtn.addEventListener('click', async () => {
+      await ctx.renderVisualization(ctx.currentRange);
+    });
+  }
+
+  // Quick-limits panel interactions
+  const quickLimitsList = document.getElementById('quick-limits-list');
+  if (quickLimitsList) {
+    quickLimitsList.addEventListener('click', async (event) => {
+      const { domain, action } = event.target.dataset || {};
+      if (!domain || !action) return;
+      if (action === 'quick-toggle') {
+        const desiredState = event.target.checked;
+        try {
+          const limits = await getLimits();
+          let limitConfig = limits[domain] ? normalizeLimitConfig(limits[domain]) : null;
+          if (!limitConfig && desiredState) limitConfig = createDefaultLimitConfig();
+          if (!limitConfig) {
+            event.target.checked = false;
+            return;
+          }
+          limitConfig.enabled = desiredState;
+          await setLimitForDomain(domain, limitConfig);
+          await updateBlockingRules();
+          await ctx.renderVisualization(ctx.currentRange);
+        } catch (error) {
+          console.error('Unable to toggle limit:', error);
+          event.target.checked = !desiredState;
+        }
+      } else if (action === 'quick-customize') {
+        await ctx.showSettingsView();
+        if (dom.limitForm) {
+          const limits = await getLimits();
+          const limitConfig = limits[domain]
+            ? normalizeLimitConfig(limits[domain])
+            : createDefaultLimitConfig();
+          ctx.applyLimitConfigToForm(domain, limitConfig);
+          dom.limitForm.scrollIntoView({ behavior: 'smooth', block: 'start' });
+          dom.limitForm.elements.domain.focus();
+        }
+      }
+    });
+  }
+
+  // Export to JSON
+  if (dom.exportJsonBtn) {
+    dom.exportJsonBtn.addEventListener('click', async () => {
       try {
         const data = await chrome.storage.local.get(['visits', 'limits', 'settings']);
         const jsonString = JSON.stringify(data, null, 2);
         const blob = new Blob([jsonString], { type: 'application/json' });
         const url = URL.createObjectURL(blob);
-        const timestamp = getTodayKey();
-        const filename = `focusbear-data-${timestamp}.json`;
-
+        const filename = `focusbear-data-${getTodayKey()}.json`;
         const a = document.createElement('a');
         a.href = url;
         a.download = filename;
         a.click();
-
         URL.revokeObjectURL(url);
-        showSettingsToast(`Exported data as ${filename}`);
+        ctx.showSettingsToast(`Exported data as ${filename}`);
       } catch (error) {
         console.error('Export JSON error:', error);
-        showSettingsToast('Unable to export JSON. Try again.');
+        ctx.showSettingsToast('Unable to export JSON. Try again.');
       }
     });
   }
 
-  if (exportCsvBtn) {
-    exportCsvBtn.addEventListener('click', async () => {
+  // Export to CSV
+  if (dom.exportCsvBtn) {
+    dom.exportCsvBtn.addEventListener('click', async () => {
       try {
         const data = await chrome.storage.local.get(['visits', 'limits']);
         const visits = data.visits || {};
         const limits = data.limits || {};
-
-        // Build CSV content
         let csv = 'Date,Domain,Path,Visit Count,Daily Limit\n';
-
         Object.entries(visits).forEach(([date, dateVisits]) => {
-          Object.entries(dateVisits).forEach(([domain, domainData]) => {
-            const limit = limits[domain] || 'No limit';
+          Object.entries(dateVisits).forEach(([domainName, domainData]) => {
+            const limit = limits[domainName] || 'No limit';
             const count = domainData.count || 0;
-
-            // Main domain row
-            csv += `"${date}","${domain}","/",${count},"${limit}"\n`;
-
-            // Subpath rows
+            csv += `"${date}","${domainName}","/",${count},"${limit}"\n`;
             if (domainData.subpaths) {
               Object.entries(domainData.subpaths).forEach(([subpath, subpathData]) => {
-                csv += `"${date}","${domain}","${subpath}",${subpathData.count},"${limit}"\n`;
+                csv += `"${date}","${domainName}","${subpath}",${subpathData.count},"${limit}"\n`;
               });
             }
           });
         });
-
         const blob = new Blob([csv], { type: 'text/csv' });
         const url = URL.createObjectURL(blob);
-        const timestamp = getTodayKey();
-        const filename = `focusbear-data-${timestamp}.csv`;
-
+        const filename = `focusbear-data-${getTodayKey()}.csv`;
         const a = document.createElement('a');
         a.href = url;
         a.download = filename;
         a.click();
-
         URL.revokeObjectURL(url);
-        showSettingsToast(`Exported data as ${filename}`);
+        ctx.showSettingsToast(`Exported data as ${filename}`);
       } catch (error) {
         console.error('Export CSV error:', error);
-        showSettingsToast('Unable to export CSV. Try again.');
+        ctx.showSettingsToast('Unable to export CSV. Try again.');
       }
     });
   }
 
-  // Listen for custom event to open domain settings from graph drilldown
+  // Graph drilldown → open settings for that domain
   window.addEventListener('openDomainSettings', async (event) => {
     const { domain } = event.detail || {};
     if (!domain) return;
-
     try {
-      await showSettingsView();
-
-      if (limitForm) {
+      await ctx.showSettingsView();
+      if (dom.limitForm) {
         const limits = await getLimits();
         const limitConfig = limits[domain]
           ? normalizeLimitConfig(limits[domain])
           : createDefaultLimitConfig();
-        applyLimitConfigToForm(domain, limitConfig);
-
-        // Scroll to form
-        limitForm.scrollIntoView({ behavior: 'smooth', block: 'start' });
-        limitForm.querySelector('input[name="domain"]')?.focus();
+        ctx.applyLimitConfigToForm(domain, limitConfig);
+        dom.limitForm.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        dom.limitForm.querySelector('input[name="domain"]')?.focus();
       }
     } catch (error) {
       console.error('Failed to open domain settings:', error);
     }
   });
 
-  // Performance monitoring
+  // Initial render + performance log (awaited so setupVisualizationPage resolves
+  // only after `loading` is hidden — matches the contract the tests assert).
   const perfStart = performance.now();
-
   try {
-    await renderVisualization(currentRange);
-    if (loading) {
-      loading.style.display = 'none';
-    }
-
-    // Log performance metrics
-    const perfEnd = performance.now();
-    const loadTime = Math.round(perfEnd - perfStart);
+    await ctx.renderVisualization(ctx.currentRange);
+    if (dom.loading) dom.loading.style.display = 'none';
+    const loadTime = Math.round(performance.now() - perfStart);
     console.log(`[FocusBear Performance] Page load time: ${loadTime}ms`);
     if (loadTime > 300) {
       console.warn('[FocusBear Performance] Load time exceeds target of 300ms');
     }
   } catch (error) {
     console.error('Error initializing visualization page:', error);
-    if (loading) {
-      loading.textContent = 'Error loading FocusBear';
-    }
+    if (dom.loading) dom.loading.textContent = 'Error loading FocusBear';
   }
+}
+
+/**
+ * Wire up the visualization UI by composing the three single-purpose wirers.
+ * Public entry point — external callers (dashboard, popup) keep using it.
+ * @param {Object} options
+ * @param {string} [options.defaultRange='today']
+ * @param {{width?:number,height?:number}} [options.graphDimensions]
+ * @param {number} [options.listLimit=10]
+ * @param {boolean} [options.fullPage=false]
+ * @param {(data:Object)=>void} [options.onDataLoaded]
+ */
+export async function setupVisualizationPage(options = {}) {
+  const { fullPage = false } = options;
+  if (fullPage) {
+    document.body.classList.add('dashboard-view');
+  }
+
+  const ctx = buildVisualizationContext(options);
+  // Order matters: render first (provides ctx.renderVisualization), then
+  // settings (exposes showSettingsView/applyLimitConfigToForm/showSettingsToast),
+  // then actions which consumes both and runs the initial render.
+  wireVisualizationRender(ctx);
+  wireVisualizationSettings(ctx);
+  await wireVisualizationActions(ctx, options);
 }

--- a/src/dashboard/dashboard.js
+++ b/src/dashboard/dashboard.js
@@ -33,6 +33,9 @@ function getStatusColor(percent) {
   if (percent > 80) return 'var(--color-warning)';
   return 'var(--color-success)';
 }
+// "Near limit" threshold: 80% of a configured limit triggers the near-limit warning.
+const NEAR_LIMIT_THRESHOLD = 0.8;
+
 const tableFilters = {
   query: '',
   sortField: 'count',
@@ -632,8 +635,8 @@ function renderTable() {
 
       const overFiveHour = fiveHourLimit && fiveHourCount >= fiveHourLimit;
       const overDaily = dailyLimit && todayCount >= dailyLimit;
-      const nearFiveHour = fiveHourLimit && fiveHourCount >= fiveHourLimit * 0.8;
-      const nearDaily = dailyLimit && todayCount >= dailyLimit * 0.8;
+      const nearFiveHour = fiveHourLimit && fiveHourCount >= fiveHourLimit * NEAR_LIMIT_THRESHOLD;
+      const nearDaily = dailyLimit && todayCount >= dailyLimit * NEAR_LIMIT_THRESHOLD;
 
       if (overFiveHour || overDaily) {
         statusBadge.classList.add('over-limit');
@@ -1075,9 +1078,6 @@ async function updateStreakDisplay() {
   }
 }
 
-/**
- * Update focus score display in header
- */
 /**
  * Update focus score display in header
  */

--- a/src/popup/graph.js
+++ b/src/popup/graph.js
@@ -35,7 +35,7 @@ export function renderRadialGraph(container, data, options = {}) {
     return;
   }
 
-  // Import D3 from CDN (loaded in popup.html/dashboard.html)
+  // D3 is vendored locally (loaded via vendor/d3.min.js in popup.html / dashboard.html)
   const { d3 } = window;
   if (!d3) {
     console.error('D3.js not loaded');


### PR DESCRIPTION
## Summary

Implements issue #50 (Phase P3, task 3.9): clean-code pass atop the hardened code.

### Closes
- F-CLEAN-001: split `setupVisualizationPage` god function
- F-CLEAN-004: simplify double-negative preference check
- F-CLEAN-005: extract named constants for magic values
- F-CLEAN-006: fix misleading CDN comment
- F-CLEAN-007: remove duplicate JSDoc

## Changes

- **F-CLEAN-001**: `setupVisualizationPage` in `src/common/visualization-page.js` went from a ~590-line god function to a ~14-line orchestrator that composes three named single-purpose wirers:
  - `wireVisualizationRender` — render pipeline (graph + list + quick-limits) — ~198 lines
  - `wireVisualizationSettings` — settings view nav, limit list, toasts — ~189 lines
  - `wireVisualizationActions` — time filter, comparison, refresh, exports, drilldown, initial render — ~181 lines
  - A small `wireLimitFormAndReset` sub-helper called from settings, ~119 lines.
  - All shared DOM refs and mutable state (`currentRange`, `cleanupGraph`, timeouts) live on a `buildVisualizationContext` context object.
- **F-CLEAN-004**: replaced the contradictory `!preferences.enabled && preferences.enabled !== false` with a clean `preferences.enabled === undefined` check in `src/background/notifications.js`.
- **F-CLEAN-005**: extracted `FIVE_HOURS_MS` (`src/background/limits.js`, used in 2 places), `FOCUS_BEAR_BADGE_COLOR` (`src/background/badge.js`), and `NEAR_LIMIT_THRESHOLD` (added in `src/dashboard/dashboard.js` and `src/common/visualization-page.js`). The 0.8 magic value was also already defined inline in two places — both now use the shared constant.
- **F-CLEAN-006**: `src/popup/graph.js` comment changed from "Import D3 from CDN" to "D3 is vendored locally (loaded via vendor/d3.min.js in popup.html / dashboard.html)".
- **F-CLEAN-007**: removed the duplicate JSDoc block for `updateFocusScoreDisplay` in `src/dashboard/dashboard.js`.

## Test Results

- `npm test -- --ci`: 253/255 pass (the 2 failures are pre-existing in `tests/blocked.test.js` and `tests/blocking-domain.test.js` — both are `delete window.location` jsdom quirks unrelated to this change; confirmed pre-existing by running on `main` before changes).
- `npm run lint`: clean (prettier + eslint).
- `npm run build`: clean (dist/manifest.json stamped with version_name `0.2.0-8b0fa58`).
- Pre-commit hooks (lint-staged: eslint + prettier + jest --bail --findRelatedTests) all green.

## Files Changed

```
src/background/badge.js          |   5 +-
src/background/limits.js         |  11 +-
src/background/notifications.js  |   4 +-
src/common/visualization-page.js | 894 +++++++++++++++++++---------------------
src/dashboard/dashboard.js       |  10 +-
src/popup/graph.js               |   2 +-
6 files changed, 423 insertions(+), 503 deletions(-)
```

Net: **80 lines removed** while making every named responsibility testable and the god function go from 590 → 14 lines.

## Acceptance Criteria

- [x] `setupVisualizationPage` splits into 3 named responsibilities, each under ~200 lines
- [x] Magic values moved to named constants; comments fixed; preference check simplified
- [x] Suite green at ≥ recorded rate (253/255 vs recorded 250/255); lint clean

Closes #50