### PR TITLE
refactor(perf): drop redundant updateBlockingRules + dynamic limits import (#52)

### DIFF
--- a/src/background/tracking.js
+++ b/src/background/tracking.js
@@ -4,7 +4,7 @@
  */
 
 import { incrementVisit } from './storage.js';
-import { updateBlockingRules } from './limits.js';
+import { checkLimit } from './limits.js';
 import { updateVisitBadge } from './badge.js';
 import { checkLimitWarnings, showAchievementUnlocked } from './notifications.js';
 import { checkAchievements } from './achievements.js';
@@ -83,8 +83,9 @@ async function trackTabFocus(tabId) {
       await showAchievementUnlocked(newlyUnlocked[0]);
     }
 
-    // Update blocking rules in case a limit was just exceeded
-    await updateBlockingRules();
+    // Blocking rules are refreshed by the chrome.storage.onChanged listener in
+    // limits.js, which fires whenever visits/limits are written. No need for an
+    // explicit per-visit call here.
   } catch (error) {
     // Tab might have been closed or URL inaccessible
     console.debug('Could not track tab:', error.message);
@@ -99,7 +100,6 @@ async function trackTabFocus(tabId) {
  */
 async function showCountdownToastIfNeeded(tabId, domain) {
   try {
-    const { checkLimit } = await import('./limits.js');
     const limitStatus = await checkLimit(domain);
 
     // Only show toast if domain has a limit


### PR DESCRIPTION
## Summary

Drops two tiny redundancies from the focus-switch hot path in `src/background/tracking.js`:

1. **Remove explicit `updateBlockingRules()` per visit.** The `chrome.storage.onChanged` listener in `src/background/limits.js` (l.390-393) already refreshes rules on every `visits`/`limits` write, and `incrementVisit` triggers a write. The explicit call caused a redundant second invocation per focus switch. The previous code was a true double-call (F-PERF-003).
2. **Replace `await import('./limits.js')` with a static top-level import.** `checkLimit` is now imported alongside the other module-level imports in `tracking.js`, removing a per-call dynamic-module fetch on the hot path (F-PERF-006).

### Diff (4 +/4 - in `src/background/tracking.js`)

- L7 — `import { updateBlockingRules } from './limits.js'` → `import { checkLimit } from './limits.js'`
- L86-87 — removed `await updateBlockingRules()`, left a comment pointing at the listener.
- L102 — removed `const { checkLimit } = await import('./limits.js');` (already statically imported).

## Acceptance Criteria

- [x] Per focus switch, `updateBlockingRules` runs at most once (the `onChanged` listener is the sole caller; the explicit call site is gone).
- [x] `tracking.js` imports `checkLimit` statically (top-level `import` at L5).
- [x] Suite green at recorded rate; lint clean. (Dashboard ≤200ms DevTools check is a manual visual perf trace, not automatable in CI.)

## Test Results

`npm test -- --ci`: 253 pass / 2 pre-existing failures / 255 total. The 2 failures (`blocking-domain.test.js`, `blocked.test.js`) fail identically on the base branch with the original `tracking.js`; root cause is `delete window.location` on a jsdom `Window` (jsdom 27+ disallows it). Unrelated to this change.

`npm run lint`: clean (`format:check` + `eslint src/**/*.js`).

## Decision Record

- **Profile:** light (Effort S, single-file 4-line change, no new behavior, deterministic).
- **Workspace:** in-place.
- **Branch:** `fix/52-hotpath-perf` (named per user instruction; default would have been `refactor/52-4-2-hot-path-perf-cleanup`).
- **Branch type:** improvement, no breaking change.
- **Other call sites of `updateBlockingRules`** (dashboard/blocking.js, common/visualization-page.js) intentionally left intact — those are user-triggered actions, not the per-visit hot path.

## Verification

```
git grep -n "await import" src/background/tracking.js   # no matches
git grep -n "updateBlockingRules" src/background/tracking.js   # no matches
```

Closes #52