### PR TITLE
fix(sec): harden CSV export against formula-injection (4.4) (#54)

### DIFF
--- a/src/common/csv-escape.js
+++ b/src/common/csv-escape.js
@@ -1,0 +1,75 @@
+/**
+ * CSV cell escaping.
+ *
+ * Two threats are handled here:
+ *   1. CSV structural escaping (RFC 4180): any cell containing `,`, `"`, `\n`, or `\r`
+ *      is wrapped in double-quotes, and embedded `"` is doubled.
+ *   2. Formula-injection escaping (OWASP): a cell whose first character is one of
+ *      `=`, `+`, `-`, `@`, TAB (`\t`) or CR (`\r`) is prefixed with a single
+ *      apostrophe (`'`) so spreadsheet apps (Excel, Google Sheets, LibreOffice)
+ *      treat the value as text instead of executing it as a formula.
+ *
+ * Both passes are required: quoting alone does NOT stop formula injection in
+ * Excel/Sheets — they evaluate the cell *after* unquoting.
+ *
+ * Numbers (visit counts) and booleans should not be passed through this helper;
+ * it is intended for string cells. Numbers are emitted as their decimal form by
+ * the caller.
+ */
+
+/** Characters that spreadsheet apps interpret as a formula starter. */
+export const FORMULA_PREFIXES = ['=', '+', '-', '@', '\t', '\r'];
+
+/**
+ * Returns true when the given string cell would be interpreted as a formula by
+ * a spreadsheet app and therefore needs a leading apostrophe.
+ *
+ * Exported for testing and for any future call-site that needs the check
+ * without the full escape.
+ *
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+export function isFormulaPrefix(value) {
+  if (typeof value !== 'string' || value.length === 0) return false;
+  return FORMULA_PREFIXES.includes(value[0]);
+}
+
+/**
+ * Escape a single CSV cell. Returns a plain string safe to interpolate into
+ * a CSV row joined by `,` and terminated with `\n`.
+ *
+ * @param {unknown} value  Cell value; coerced to string. `null`/`undefined`
+ *   become the empty string. Numbers are formatted via `String(n)`.
+ * @returns {string}       Escaped cell (already RFC-4180 quoted when needed,
+ *   and apostrophe-prefixed when the value would be a formula).
+ */
+export function escapeCsvCell(value) {
+  if (value === null || value === undefined) return '';
+  let str = typeof value === 'string' ? value : String(value);
+
+  // 1. Formula-injection guard: prefix with a single apostrophe so the
+  //    spreadsheet treats the cell as text. We do this BEFORE quoting so the
+  //    resulting `'"=cmd…'` is wrapped in quotes.
+  if (isFormulaPrefix(str)) {
+    str = `'${str}`;
+  }
+
+  // 2. RFC 4180 quoting: quote the cell when it contains a comma, double
+  //    quote, CR, or LF; double any embedded double quotes.
+  const needsQuoting = /[",\r\n]/.test(str);
+  if (needsQuoting) {
+    return `"${str.replace(/"/g, '""')}"`;
+  }
+  return str;
+}
+
+/**
+ * Build a single CSV row from an array of cell values.
+ *
+ * @param {readonly unknown[]} cells
+ * @returns {string}  Cells joined by `,` followed by `\n`.
+ */
+export function csvRow(cells) {
+  return `${cells.map(escapeCsvCell).join(',')}\n`;
+}

--- a/src/common/visualization-page.js
+++ b/src/common/visualization-page.js
@@ -16,6 +16,7 @@ import {
 import { updateBlockingRules } from '../background/limits.js';
 import { getTodayKey, aggregateVisitsInRange } from './date-utils.js';
 import { validateLimitConfig, validateDomain } from './limit-validation.js';
+import { csvRow } from './csv-escape.js';
 
 // "Near limit" threshold: 80% of a configured limit triggers the near-limit warning.
 const NEAR_LIMIT_THRESHOLD = 0.8;
@@ -990,15 +991,20 @@ async function wireVisualizationActions(ctx, _options) {
         const data = await chrome.storage.local.get(['visits', 'limits']);
         const visits = data.visits || {};
         const limits = data.limits || {};
-        let csv = 'Date,Domain,Path,Visit Count,Daily Limit\n';
+        // csvRow() escapes each cell for RFC 4180 and prefixes formula-injection
+        // starters (= + - @ \t \r) with an apostrophe so spreadsheet apps open
+        // the value as text. The visit count and limit are emitted as strings —
+        // csvRow's structural escaping still applies if the limit string
+        // contains a comma.
+        let csv = csvRow(['Date', 'Domain', 'Path', 'Visit Count', 'Daily Limit']);
         Object.entries(visits).forEach(([date, dateVisits]) => {
           Object.entries(dateVisits).forEach(([domainName, domainData]) => {
             const limit = limits[domainName] || 'No limit';
             const count = domainData.count || 0;
-            csv += `"${date}","${domainName}","/",${count},"${limit}"\n`;
+            csv += csvRow([date, domainName, '/', count, limit]);
             if (domainData.subpaths) {
               Object.entries(domainData.subpaths).forEach(([subpath, subpathData]) => {
-                csv += `"${date}","${domainName}","${subpath}",${subpathData.count},"${limit}"\n`;
+                csv += csvRow([date, domainName, subpath, subpathData.count, limit]);
               });
             }
           });

--- a/tests/csv-escape.test.js
+++ b/tests/csv-escape.test.js
@@ -1,0 +1,103 @@
+import {
+  escapeCsvCell,
+  csvRow,
+  isFormulaPrefix,
+  FORMULA_PREFIXES,
+} from '../src/common/csv-escape.js';
+
+describe('csv-escape', () => {
+  describe('isFormulaPrefix', () => {
+    test.each(FORMULA_PREFIXES)('detects %p as a formula prefix', (ch) => {
+      expect(isFormulaPrefix(ch)).toBe(true);
+      expect(isFormulaPrefix(`${ch}cmd|'/c calc'!A0`)).toBe(true);
+    });
+
+    test('returns false for empty / non-string / safe cells', () => {
+      expect(isFormulaPrefix('')).toBe(false);
+      expect(isFormulaPrefix(null)).toBe(false);
+      expect(isFormulaPrefix(undefined)).toBe(false);
+      expect(isFormulaPrefix(42)).toBe(false);
+      expect(isFormulaPrefix('example.com/path')).toBe(false);
+      expect(isFormulaPrefix(' normal text')).toBe(false);
+      expect(isFormulaPrefix('=')).toBe(true);
+    });
+  });
+
+  describe('escapeCsvCell', () => {
+    test('returns empty string for null / undefined', () => {
+      expect(escapeCsvCell(null)).toBe('');
+      expect(escapeCsvCell(undefined)).toBe('');
+    });
+
+    test('coerces numbers to their decimal form', () => {
+      expect(escapeCsvCell(0)).toBe('0');
+      expect(escapeCsvCell(7)).toBe('7');
+    });
+
+    test('quotes cells containing commas, quotes, CR or LF', () => {
+      expect(escapeCsvCell('a,b')).toBe('"a,b"');
+      expect(escapeCsvCell('he said "hi"')).toBe('"he said ""hi"""');
+      expect(escapeCsvCell('line1\nline2')).toBe('"line1\nline2"');
+      expect(escapeCsvCell('carriage\rreturn')).toBe('"carriage\rreturn"');
+    });
+
+    test('prefixes formula-injection starters with an apostrophe', () => {
+      // Embedded quote forces RFC 4180 quoting; we also prefix the cell with
+      // an apostrophe so a spreadsheet refuses to evaluate `=cmd…`.
+      expect(escapeCsvCell('=cmd|"/c calc"!A0')).toBe('"\'=cmd|""/c calc""!A0"');
+      // Cells without comma / quote / newline need only the apostrophe prefix.
+      expect(escapeCsvCell('+1+1')).toBe("'+1+1");
+      expect(escapeCsvCell('-2+3')).toBe("'-2+3");
+      expect(escapeCsvCell('@SUM(A1:A2)')).toBe("'@SUM(A1:A2)");
+      // TAB is also a formula starter; still gets the apostrophe prefix.
+      expect(escapeCsvCell('\tinjected')).toBe("'\tinjected");
+    });
+
+    test('does not touch a leading apostrophe that was not added by us', () => {
+      // A cell that already starts with an apostrophe is safe: the spreadsheet
+      // treats the rest as text. We don't double-prefix.
+      expect(escapeCsvCell("'=2+2")).toBe("'=2+2");
+    });
+
+    test('leaves a plain, safe cell unchanged', () => {
+      expect(escapeCsvCell('example.com')).toBe('example.com');
+      expect(escapeCsvCell('/api/v1/users')).toBe('/api/v1/users');
+    });
+  });
+
+  describe('csvRow', () => {
+    test('joins cells with commas and terminates with newline', () => {
+      expect(csvRow(['a', 'b', 'c'])).toBe('a,b,c\n');
+    });
+
+    test('round-trips a malicious subpath through the CSV layer', () => {
+      // Acceptance: a subpath beginning with `=` round-trips through the CSV
+      // and opens as text in a spreadsheet. The export handler must emit an
+      // apostrophe-prefixed cell so a parser sees the literal text and a
+      // spreadsheet refuses to evaluate it.
+      const subpath = '=cmd|"/c calc"!A0';
+      const row = csvRow(['2026-01-01', 'evil.test', subpath, 1, 'No limit']);
+      // Only the malicious cell needs both prefixing and quoting (because of
+      // its embedded `"` and `,`-adjacent content). The date / domain / count
+      // / limit cells are unquoted RFC 4180.
+      expect(row).toBe('2026-01-01,evil.test,"\'=cmd|""/c calc""!A0",1,No limit\n');
+
+      // The malicious cell starts with a single apostrophe — that is the
+      // spreadsheet signal that the rest is text, not a formula. (We use a
+      // string-contains check rather than split-on-comma because the cell
+      // itself contains commas, which a naive split would mangle.)
+      expect(row).toContain("'=");
+      expect(row).not.toMatch(/(^|,)=/);
+    });
+
+    test('escapes every prefix character across all four trigger chars', () => {
+      // Every formula-injection starter is apostrophe-prefixed; otherwise the
+      // cell passes through unchanged (no structural quoting needed for safe
+      // values without commas / quotes / newlines).
+      expect(escapeCsvCell('=foo')).toBe("'=foo");
+      expect(escapeCsvCell('+foo')).toBe("'+foo");
+      expect(escapeCsvCell('-foo')).toBe("'-foo");
+      expect(escapeCsvCell('@foo')).toBe("'@foo");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The dashboard / popup CSV export built rows with raw template-string
interpolation, so a visited subpath like `=cmd|"/c calc"!A0` (or any
domain / path starting with `= + - @`) was emitted verbatim into the
CSV. Spreadsheet apps (Excel, Google Sheets, LibreOffice) auto-evaluate
such cells as formulas, opening a CSV-formula-injection vector
(**F-SEC-002**).

## Fix

- New helper `src/common/csv-escape.js`:
  - `escapeCsvCell(value)` prefixes cells whose first char is
    `= + - @ TAB CR` with a single apostrophe, then RFC-4180 quotes
    the cell when it contains `,`, `"`, `\r`, or `\n` (doubling
    embedded quotes).
  - `csvRow(cells)` joins cells with `,` + `\n`.
- `src/common/visualization-page.js` now builds the CSV via
  `csvRow([...])` instead of `"${…}"` interpolation. The header row
  and the date / domain / path / count / limit cells all flow through
  the same escaper.

JSON export path is unchanged — it remains the safe long-form path.

## Test

`tests/csv-escape.test.js` (16 tests) covers:
- Detection of every formula-injection prefix.
- Apostrophe-prefixing for `= + - @ TAB CR`.
- RFC-4180 quoting for cells with commas / embedded quotes / newlines.
- A round-trip test that asserts a subpath beginning with `=` is
  emitted as `'=cmd|…` (leading apostrophe), which spreadsheets
  interpret as text.

## Acceptance Criteria

- [x] A subpath beginning with `=` round-trips through the CSV and
  opens as text in a spreadsheet (test asserts the apostrophe
  prefixing).
- [x] Existing export UX unchanged (same button, same toast, same
  filename).
- [x] Suite green at the recorded rate — full `npm test -- --ci`
  passes 269/271; the 2 failing suites (`blocked.test.js`,
  `blocking-domain.test.js`) were already failing on `main` at the
  recorded baseline (verified via stash-and-rerun) and are unrelated
  to this change. `npm run lint` is clean.

Closes #54.