### PR TITLE
fix(categories): label-aligned matcher to drop substring false positives (4.8) (#58)

### DIFF
--- a/src/common/categories.js
+++ b/src/common/categories.js
@@ -117,16 +117,60 @@ export const CATEGORY_CONFIG = {
 };
 
 /**
+ * Check whether a keyword matches a domain using label-aligned rules.
+ *
+ * The legacy substring `includes` match over-matched (F-BUG-010): the
+ * user's dev URL `target.example.net` was classified as shopping because
+ * `'target.example.net'.includes('target')` is true. The new rule
+ * requires the keyword to align to whole labels:
+ *
+ *   1. domain === keyword                           e.g. `x.com`
+ *   2. registered part of domain === keyword        e.g. `target.com`
+ *      (registered = labels minus the TLD label)        registered = `target`
+ *   3. registered part ends with `.` + keyword      e.g. `api.target.com`
+ *      (subdomain of a registered keyword)               registered = `api.target`
+ *
+ * Multi-label keywords (`meet.google`, `docs.google`, `dev.to`) work
+ * the same way: the keyword is matched against the registered part
+ * (everything except the rightmost TLD label).
+ *
+ * `target.example.net` is rejected because its registered part is
+ * `target.example`, which neither equals nor ends with `.target`.
+ * `news.example.com` is rejected the same way: it is the "nuanced"
+ * dev-URL case from the issue. `api.target.com` and `target.com` both
+ * match because their registered parts are `api.target` and `target`.
+ *
+ * Matching is case-insensitive (callers lowercase the inputs) and
+ * ignores a trailing dot on the domain.
+ *
+ * @param {string} domain - Lowercased domain (no protocol, no path).
+ * @param {string} keyword - Lowercased keyword from a category config.
+ * @returns {boolean} True when the keyword matches the domain.
+ */
+function matchesKeyword(domain, keyword) {
+  if (!domain || !keyword) return false;
+  const host = domain.endsWith('.') ? domain.slice(0, -1) : domain;
+  if (!host) return false;
+  if (host === keyword) return true;
+  const labels = host.split('.').filter((l) => l.length > 0);
+  if (labels.length < 2) return false;
+  // Registered domain = everything except the rightmost (TLD) label.
+  const registered = labels.slice(0, -1).join('.');
+  if (registered === keyword) return true;
+  return registered.endsWith(`.${keyword}`);
+}
+
+/**
  * Categorize domain into a group
  * @param {string} domain - Domain name
  * @returns {Object} - Category info {name, color, key, sentiment}
  */
 export function categorizeDomain(domain) {
-  const domainLower = domain.toLowerCase();
+  const domainLower = (domain || '').toLowerCase();
 
   /* eslint-disable implicit-arrow-linebreak, function-paren-newline */
   const match = Object.entries(CATEGORY_CONFIG).find(([, config]) =>
-    config.keywords.some((k) => domainLower.includes(k)),
+    config.keywords.some((k) => matchesKeyword(domainLower, k)),
   );
   /* eslint-enable implicit-arrow-linebreak, function-paren-newline */
 

--- a/tests/categories.test.js
+++ b/tests/categories.test.js
@@ -65,15 +65,66 @@ describe('categories', () => {
     });
   });
 
-  test('subdomain containing keyword still matches', () => {
+  test('subdomain containing keyword still matches (real second-level)', () => {
     expect(categorizeDomain('m.facebook.com').key).toBe('social');
     expect(categorizeDomain('music.youtube.com').key).toBe('entertainment');
+    expect(categorizeDomain('api.github.com').key).toBe('development');
+    expect(categorizeDomain('shop.target.com').key).toBe('shopping');
   });
 
-  test('false-positive substring is currently categorized (documents current behavior)', () => {
-    // e.g., a domain containing 'news' substring matches news category by design
-    expect(categorizeDomain('newsagency.com').key).toBe('news');
-    // an unrelated domain with no keyword falls to other
-    expect(categorizeDomain('myawesomesite.io').key).toBe('other');
+  // F-BUG-010: substring `includes` matching over-matched. The new matcher
+  // requires the keyword to be the registered second-level domain (or a
+  // multi-label suffix), so arbitrary first-label matches like
+  // `target.example.net` and `news.example.com` are NOT categorized.
+  test('first-label substring does not match (F-BUG-010)', () => {
+    expect(categorizeDomain('target.example.net').key).toBe('other');
+    expect(categorizeDomain('news.example.com').key).toBe('other');
+    expect(categorizeDomain('github.mycompany.io').key).toBe('other');
+    expect(categorizeDomain('amazon.evil.test').key).toBe('other');
+  });
+
+  // Per acceptance: at least one false-positive case per keyword list.
+  // Each list contains a keyword that has a common substring trap; we
+  // exercise a non-keyword domain that previously matched.
+  test('false-positive coverage per category (F-BUG-010)', () => {
+    // social
+    expect(categorizeDomain('facebook-login.example.com').key).toBe('other');
+    // entertainment
+    expect(categorizeDomain('netflixcdn.example.net').key).toBe('other');
+    // productivity
+    expect(categorizeDomain('slackbot.example.com').key).toBe('other');
+    // development
+    expect(categorizeDomain('githubclone.example.io').key).toBe('other');
+    // news
+    expect(categorizeDomain('newsdaily.example.org').key).toBe('other');
+    // shopping
+    expect(categorizeDomain('target.example.net').key).toBe('other');
+  });
+
+  test('multi-label keywords still match their full domain', () => {
+    // x.com
+    expect(categorizeDomain('x.com').key).toBe('social');
+    // dev.to
+    expect(categorizeDomain('dev.to').key).toBe('development');
+    // docs.google / drive.google / meet.google (productivity multi-labels)
+    expect(categorizeDomain('docs.google.com').key).toBe('productivity');
+    expect(categorizeDomain('drive.google.com').key).toBe('productivity');
+    expect(categorizeDomain('meet.google.com').key).toBe('productivity');
+  });
+
+  test('multi-label keyword does not match a label that merely contains it', () => {
+    // `meet.google` must not match `meet.googleology.com`
+    expect(categorizeDomain('meet.googleology.com').key).toBe('other');
+    // `x.com` must not match `x.company.com`
+    expect(categorizeDomain('x.company.com').key).toBe('other');
+  });
+
+  test('news keyword: real news sites still match', () => {
+    expect(categorizeDomain('cnn.com').key).toBe('news');
+    expect(categorizeDomain('www.nytimes.com').key).toBe('news');
+    // "Nuanced" case from the issue: a subdomain `news.<x>` where the
+    // second-level is not a registered news keyword is NOT classified
+    // as news (avoids the dev-URL false positive).
+    expect(categorizeDomain('news.example.com').key).toBe('other');
   });
 });


### PR DESCRIPTION
## Summary

Replace substring `includes` category matching with a label-aligned
ends-with / exact match in `categorizeDomain` (F-BUG-010). Adds
regression tests for the first-label false positive and one false
positive per category list.

## What changed

- `src/common/categories.js`: replace `domainLower.includes(keyword)`
  with a new `matchesKeyword(domain, keyword)` helper that matches
  against the registered part of the domain (labels minus the TLD),
  accepting: exact match, full registered match, or registered ends
  with `.${keyword}`.
- `tests/categories.test.js`: drop the old `documents current
  behavior` test; add four new test cases covering F-BUG-010.

## Acceptance criteria

- [x] `categorizeDomain('target.example.net')` no longer categorizes
  as shopping; `news.example.com` is no longer categorized as news.
- [x] Category tests cover at least one false-positive case per
  keyword list (six categories, six false-positive cases).
- [x] `npm run lint` clean. `npm test -- --ci` shows 279/281 pass;
  the 2 failing tests (`blocked.test.js`, `blocking-domain.test.js`)
  are pre-existing on `fix/57-coverage-ci-gates` (jsdom
  `delete window.location` incompatibility) and unrelated to this
  fix. My changes add 4 net new passing tests and zero new failures.
- [x] `npm run build` clean.

## Decision record

- **Profile:** light (issue metadata: Effort S, Priority low).
- **Why label-aligned instead of pure ends-with:** the keyword list
  contains multi-label entries (`x.com`, `meet.google`,
  `docs.google`, `dev.to`, `repl.it`). A naive
  `endsWith('.' + keyword)` rejects these unless we strip the TLD
  first. Working on the registered part (labels minus the TLD) lets
  the same rule handle single- and multi-label keywords.
- **Scope of the sweep:** the modernization report's cross-cutting
  patterns (storage races, innerHTML templating, date-aggregator
  divergence, limit-format normalization) are out of scope for a
  small-scope polish task; the issue only authorises `categorizeDomain`
  plus "low-hanging items". I did not find any `categorizeDomain`
  -adjacent low-hanging items that would not balloon scope.

## Test results

`npm test -- --ci`:
```
Test Suites: 2 failed, 22 passed, 24 total
Tests:       2 failed, 279 passed, 281 total
```

The 2 failures are pre-existing on the base branch and reproduce with
my changes reverted.

## Out of scope (intentional)

- The `docs.google` / `meet.google` / `drive.google` keyword list
  still uses multi-label patterns; consolidating these into a
  subdomain-of-registered form would be a separate refactor.

Closes #58